### PR TITLE
Add approximate PEPS inner product contraction

### DIFF
--- a/examples/peps.jl
+++ b/examples/peps.jl
@@ -1,30 +1,21 @@
 using ITensors
 using ITensorNetworks
 using ITensorsVisualization
+using ITensorNetworks: Models, inds_network, project_boundary, sqnorm, sqnorm_approx
 
-using ITensorNetworks: inds_network, project_boundary, contract_approx, insert_projectors, combiners, insert_gauge, contraction_cache, boundary_mps
-using ITensorNetworks: BoundaryMPS
-using ITensorNetworks: Models
-
-N = (3, 4)
-ndims = length(N)
-
-site_dim = 2
-link_dim = 2
-site_space = site_dim #[QN(0) => site_dim]
-link_space = link_dim #[QN(0) => link_dim]
-site_inds = siteinds("S=1/2", N...; space=site_space)
-inds_net = inds_network(site_inds; linkdims=link_space)
-
-#tn_inds = vcat.(inds_net, site_inds)
-
-# TODO: symmetrize
 function peps_tensor(; linkdim, sitedim)
   # left, right, top, bottom, site
   return randn(linkdim, linkdim, linkdim, linkdim, sitedim)
 end
 
-A = peps_tensor(; linkdim=link_dim, sitedim=site_dim)
+N = (3, 4)
+ndims = length(N)
+
+site_inds = siteinds("S=1/2", N...)
+link_space = 2
+inds_net = inds_network(site_inds; linkdims=link_space)
+
+A = peps_tensor(; linkdim=link_space, sitedim=dim(first(site_inds)))
 ψ = itensor.((A,), inds_net)
 
 # Project periodic boundary indices
@@ -32,47 +23,17 @@ A = peps_tensor(; linkdim=link_dim, sitedim=site_dim)
 state = 1
 ψ = project_boundary(ψ, state)
 
-# Square the tensor network
-ψᴴ = addtags(linkinds, dag.(ψ), "ket")
-ψ′ = addtags(linkinds, ψ, "bra")
-# TODO: implement contract(commoninds, ψ′, ψᴴ)
-tn = ψ′ .* ψᴴ
-
-_cutoff = 1e-15
-_maxdim = 100
-
-# Contract in every direction
-combiner_gauge = combiners(linkinds, tn)
-tnᶜ = insert_gauge(tn, combiner_gauge)
-boundary_mpsᶜ = contract_approx(tnᶜ; maxdim=_maxdim, cutoff=_cutoff)
-
-tn_cacheᶜ = contraction_cache(tnᶜ, boundary_mpsᶜ)
-tn_cache = insert_gauge(tn_cacheᶜ, combiner_gauge)
-_boundary_mps = boundary_mps(tn_cache)
-
-#
-# Insert projectors horizontally (to measure e.g. properties
-# in a row of the network)
-#
-
 row = 2
 center = (row, :)
-tn_projected = insert_projectors(tn, _boundary_mps; center=center)
-tn_split, Pl, Pr = tn_projected
+cutoff_ = 1e-15
+maxdim_ = 100
 
-Pl_flat = reduce(vcat, Pl)
-Pr_flat = reduce(vcat, Pr)
-tn_projected_flat = mapreduce(vec, vcat, (tn_split, Pl_flat, Pr_flat))
-
-@show noncommoninds(tn_projected_flat...)
-@visualize *(tn_projected_flat...) contract=false
+sqnormψ = sqnorm(ψ)
+sqnormψ_approx = sqnorm_approx(ψ; center=center, cutoff=cutoff_, maxdim=maxdim_)
+@show noncommoninds(sqnormψ_approx...)
+@visualize *(sqnormψ_approx...) contract=false
 
 @disable_warn_order begin
-  @show contract(tn_projected_flat)[] / contract(vec(tn))[]
+  @show contract(sqnormψ_approx)[] / contract(sqnormψ)[]
 end
-
-# Uncombine the projector indices
-#tn_projected_uncombined = insert_gauge(tn_projected_flat, combiner_gauge)
-#projectors_uncombined = tn_split[(length(tn) + 1):end]
-
 

--- a/examples/peps.jl
+++ b/examples/peps.jl
@@ -2,16 +2,11 @@ using ITensors
 using ITensorNetworks
 using ITensorsVisualization
 
-using ITensorNetworks: inds_network, project_boundary, contract_approx, insert_projectors
+using ITensorNetworks: inds_network, project_boundary, contract_approx, insert_projectors, combiners, insert_gauge, contraction_cache, boundary_mps
 using ITensorNetworks: BoundaryMPS
 using ITensorNetworks: Models
 
-#model = Models.Model"ising"()
-#βc = Models.critical_point(model)
-#β = 1.001 * βc
-#@show β / βc
-
-N = (3, 3)
+N = (3, 4)
 ndims = length(N)
 
 site_dim = 2
@@ -37,163 +32,10 @@ A = peps_tensor(; linkdim=link_dim, sitedim=site_dim)
 state = 1
 ψ = project_boundary(ψ, state)
 
-function filterneighbors(f, tn, n)
-  neighbors_tn = keytype(tn)[]
-  tnₙ = tn[n]
-  for m in keys(tn)
-    if f(n, m) && hascommoninds(tnₙ, tn[m])
-      push!(neighbors_tn, m)
-    end
-  end
-  return neighbors_tn
-end
-neighbors(tn, n) = filterneighbors(≠, tn, n)
-inneighbors(tn, n) = filterneighbors(>, tn, n)
-outneighbors(tn, n) = filterneighbors(<, tn, n)
-
-function mapinds(f, ::typeof(linkinds), tn)
-  tn′ = copy(tn)
-  for n in keys(tn)
-    for nn in neighbors(tn, n)
-      commonindsₙ = commoninds(tn[n], tn[nn])
-      tn′[n] = replaceinds(tn′[n], commonindsₙ => f(commonindsₙ))
-    end
-  end
-  return tn′
-end
-
-ITensors.prime(::typeof(linkinds), tn, args...) = mapinds(x -> prime(x, args...), linkinds, tn)
-ITensors.addtags(::typeof(linkinds), tn, args...) = mapinds(x -> addtags(x, args...), linkinds, tn)
-
-## function ITensors.addtags(::typeof(linkinds), tn, args...)
-##   tn′ = copy(tn)
-##   for n in keys(tn)
-##     for nn in neighbors(tn, n)
-##       commonindsₙ = commoninds(tn[n], tn[nn])
-##       tn′[n] = replaceinds(tn′[n], commonindsₙ => prime(commonindsₙ))
-##     end
-##   end
-##   return tn′
-## end
-
-# Return a dictionary from a site to a combiner
-function combiners(::typeof(linkinds), tn)
-  Cs = Dict(keys(tn) .=> (ITensor[] for _ in keys(tn)))
-  for n in keys(tn)
-    for nn in inneighbors(tn, n)
-      commonindsₙ = commoninds(tn[n], tn[nn])
-      C = combiner(commonindsₙ)
-      push!(Cs[n], C)
-      push!(Cs[nn], dag(C))
-    end
-  end
-  return Cs
-end
-
-function contraction_cache_top(tn, boundary_mps::Vector{MPS}, n)
-  tn_cache = fill(ITensor(1.0), size(tn))
-  for nrow in 1:size(tn, 1)
-    if nrow == n
-      tn_cache[nrow, :] .= boundary_mps[nrow]
-    elseif nrow > n
-      tn_cache[nrow, :] = tn[nrow, :]
-    end
-  end
-  return tn_cache
-end
-
-function contraction_cache_top(tn, boundary_mps::Vector{MPS})
-  tn_cache_top = Vector{typeof(tn)}(undef, length(boundary_mps))
-  for n in 1:length(boundary_mps)
-    tn_cache_top[n] = contraction_cache_top(tn, boundary_mps, n)
-  end
-  return tn_cache_top
-end
-
-function contraction_cache_bottom(tn, boundary_mps::Vector{MPS})
-  tn_top = rot180(tn)
-  tn_top = reverse(tn_top; dims=2)
-  boundary_mps_top = reverse(boundary_mps)
-  tn_cache_top = contraction_cache_top(tn_top, boundary_mps_top)
-  tn_cache = reverse.(tn_cache_top; dims=2)
-  tn_cache = rot180.(tn_cache)
-  return tn_cache
-end
-
-function contraction_cache_left(tn, boundary_mps::Vector{MPS})
-  tn_top = rotr90(tn)
-  tn_cache_top = contraction_cache_top(tn_top, boundary_mps)
-  tn_cache = rotl90.(tn_cache_top)
-  return tn_cache
-end
-
-function contraction_cache_right(tn, boundary_mps::Vector{MPS})
-  tn_bottom = rotr90(tn)
-  tn_cache_bottom = contraction_cache_bottom(tn_bottom, boundary_mps)
-  tn_cache = rotl90.(tn_cache_bottom)
-  return tn_cache
-end
-
-function contraction_cache(tn, boundary_mps)
-  cache_top = contraction_cache_top(tn, boundary_mps.top)
-  cache_bottom = contraction_cache_bottom(tn, boundary_mps.bottom)
-  cache_left = contraction_cache_left(tn, boundary_mps.left)
-  cache_right = contraction_cache_right(tn, boundary_mps.right)
-  return (top=cache_top, bottom=cache_bottom, left=cache_left, right=cache_right)
-end
-
-function insert_gauge(tn::NamedTuple, gauge)
-  return map(x -> insert_gauge.(x, (gauge,)), tn)
-end
-
-function insert_gauge(tn, gauge)
-  tn′ = copy(tn)
-  for n in keys(gauge)
-    for g in gauge[n]
-      if hascommoninds(tn′[n], g)
-        tn′[n] *= g
-      end
-    end
-  end
-  return tn′
-end
-
-function boundary_mps_top(tn)
-  @show length(tn)
-  @show inds.(MPS(tn[1][1, :]))
-  @show inds.(MPS(tn[2][2, :]))
-  return [MPS(tn[n][n, :]) for n in 1:length(tn)]
-end
-
-function boundary_mps_bottom(tn)
-  tn_top = rot180.(tn)
-  tn_top = reverse.(tn_top; dims=2)
-  boundary_mps = boundary_mps_top(tn_top)
-  return boundary_mps
-end
-
-function boundary_mps_left(tn)
-  tn_top = rotr90.(tn)
-  return boundary_mps_top(tn_top)
-end
-
-function boundary_mps_right(tn)
-  tn_bottom = rotr90.(tn)
-  return boundary_mps_bottom(tn_bottom)
-end
-
-function boundary_mps(tn::NamedTuple)
-  _boundary_mps_top = boundary_mps_top(tn.top)
-  _boundary_mps_bottom = boundary_mps_bottom(tn.bottom)
-  _boundary_mps_left = boundary_mps_left(tn.left)
-  _boundary_mps_right = boundary_mps_right(tn.right)
-  return BoundaryMPS(top=_boundary_mps_top, bottom=_boundary_mps_bottom, left=_boundary_mps_left, right=_boundary_mps_right)
-end
-
 # Square the tensor network
 ψᴴ = addtags(linkinds, dag.(ψ), "ket")
-#ψ′ = prime(linkinds, ψ)
 ψ′ = addtags(linkinds, ψ, "bra")
+# TODO: implement contract(commoninds, ψ′, ψᴴ)
 tn = ψ′ .* ψᴴ
 
 _cutoff = 1e-15

--- a/examples/peps.jl
+++ b/examples/peps.jl
@@ -61,28 +61,27 @@ function ITensors.prime(::typeof(linkinds), tn)
   return tn′
 end
 
-# Return a dictionary from an edge to a combiner
+# Return a dictionary from a site to a combiner
 function combiners(::typeof(linkinds), tn)
-  tn′ = copy(tn)
+  Cs = Dict(keys(tn) .=> (ITensor[] for _ in keys(tn)))
   for n in keys(tn)
     for nn in inneighbors(tn, n)
       commonindsₙ = commoninds(tn[n], tn[nn])
       C = combiner(commonindsₙ)
-      tn′[n] = tn′[n] * C
-      tn′[nn] = tn′[nn] * C
+      push!(Cs[n], C)
+      push!(Cs[nn], dag(C))
     end
   end
-  return tn′
+  return Cs
 end
 
-function combineinds(::typeof(linkinds), tn)
+function insert_gauge(tn, gauge)
   tn′ = copy(tn)
-  for n in keys(tn)
-    for nn in inneighbors(tn, n)
-      commonindsₙ = commoninds(tn[n], tn[nn])
-      C = combiner(commonindsₙ)
-      tn′[n] = tn′[n] * C
-      tn′[nn] = tn′[nn] * C
+  for n in keys(gauge)
+    for g in gauge[n]
+      if hascommoninds(tn′[n], g)
+        tn′[n] *= g
+      end
     end
   end
   return tn′
@@ -92,38 +91,114 @@ end
 ψᴴ = dag.(ψ)
 ψ′ = prime(linkinds, ψ)
 tn = ψ′ .* ψᴴ
-# Output the link combiners as `combiner_guage`
-tnᶜ = combineinds(linkinds, tn)
 
-## _cutoff = 1e-15
-## _maxdim = 100
-## 
-## # Contract in every directions
-## boundary_mps = contract_approx(tn; maxdim=_maxdim, cutoff=_cutoff)
-## 
-## #
-## # Insert projectors horizontally (to measure e.g. properties
-## # in a row of the network)
-## #
-## 
-## row = 2
-## center = (row, :)
-## tn_projected = insert_projectors(tn, boundary_mps; center=center)
-## tn_split, Pl, Pr = tn_projected
-## 
-## Pl_flat = reduce(vcat, Pl)
-## Pr_flat = reduce(vcat, Pr)
-## tn_projected_flat = mapreduce(vec, vcat, (tn_split, Pl_flat, Pr_flat))
-## 
-## @show noncommoninds(tn_projected_flat...)
-## @visualize *(tn_projected_flat...) contract=false pause=true
-## 
-## @disable_warn_order begin
-##   @show contract(tn_projected_flat)[] / contract(vec(tn))[]
+_cutoff = 1e-15
+_maxdim = 100
+
+# Contract in every direction
+combiner_gauge = combiners(linkinds, tn)
+tnᶜ = insert_gauge(tn, combiner_gauge)
+boundary_mpsᶜ = contract_approx(tnᶜ; maxdim=_maxdim, cutoff=_cutoff)
+
+function contraction_cache_top(tn, boundary_mps::Vector{MPS}, n)
+  tn_cache = fill(ITensor(1.0), size(tn))
+  for nrow in 1:size(tn, 1)
+    if nrow == n
+      tn_cache[nrow, :] .= boundary_mps[nrow]
+    elseif nrow > n
+      tn_cache[nrow, :] = tn[nrow, :]
+    end
+  end
+  return tn_cache
+end
+
+function contraction_cache_top(tn, boundary_mps::Vector{MPS})
+  tn_cache_top = Vector{typeof(tn)}(undef, length(boundary_mps))
+  for n in 1:length(boundary_mps)
+    tn_cache_top[n] = contraction_cache_top(tn, boundary_mps, n)
+  end
+  return tn_cache_top
+end
+
+function contraction_cache_bottom(tn, boundary_mps::Vector{MPS})
+  tn_top = rot180(tn)
+  tn_top = reverse(tn_top; dims=2)
+  boundary_mps_top = reverse(boundary_mps)
+  tn_cache_top = contraction_cache_top(tn_top, boundary_mps_top)
+  tn_cache = reverse.(tn_cache_top; dims=2)
+  tn_cache = rot180.(tn_cache)
+  return tn_cache
+end
+
+function contraction_cache_left(tn, boundary_mps::Vector{MPS})
+  tn_top = rotr90(tn)
+  tn_cache_top = contraction_cache_top(tn_top, boundary_mps)
+  tn_cache = rotl90.(tn_cache_top)
+  return tn_cache
+end
+
+function contraction_cache_right(tn, boundary_mps::Vector{MPS})
+  tn_bottom = rotr90(tn)
+  tn_cache_bottom = contraction_cache_bottom(tn_bottom, boundary_mps)
+  tn_cache = rotl90.(tn_cache_bottom)
+  return tn_cache
+end
+
+function contraction_cache(tn, boundary_mps)
+  cache_top = contraction_cache_top(tnᶜ, boundary_mpsᶜ.top)
+  cache_bottom = contraction_cache_bottom(tnᶜ, boundary_mpsᶜ.bottom)
+  cache_left = contraction_cache_left(tnᶜ, boundary_mpsᶜ.left)
+  cache_right = contraction_cache_right(tnᶜ, boundary_mpsᶜ.right)
+  return (top=cache_top, bottom=cache_bottom, left=cache_left, right=cache_right)
+end
+
+
+tn_cacheᶜ = contraction_cache(tnᶜ, boundary_mpsᶜ)
+tn_cache_top_2 = insert_gauge(tn_cacheᶜ.top[2], combiner_gauge)
+
+## function insert_gauge_top_bottom(boundary_mps::ITensorNetworks.BoundaryMPS, gauge)
+##   for n in keys(gauge)
+##     n1, n2 = Tuple(n)
+##     @show n
+##     mps_top_n1 = get(boundary_mps.top, n1, nothing)
+##     mps_bottom_n1 = get(boundary_mps.bottom, n1, nothing)
+##     for g in gauge[n]
+##       if !isnothing(mps_top_n1)
+##         @show commoninds(mps_top_n1[n2], g)
+##       end
+##       if !isnothing(mps_bottom_n1)
+##         @show commoninds(mps_bottom_n1[n2], g)
+##       end
+##     end
+##   end
+##   return nothing
 ## end
-## 
-## # Uncombine the projector indices
-## tn_projected_uncombined = insert_gauge(tn_projected_flat, combiner_gauge)
-## projectors_uncombined = tn_split[(length(tn) + 1):end]
+
+#boundary_mps = insert_gauge_top_bottom(boundary_mpsᶜ, combiner_gauge)
+
+#
+# Insert projectors horizontally (to measure e.g. properties
+# in a row of the network)
+#
+
+row = 2
+center = (row, :)
+tn_projected = insert_projectors(tn, boundary_mps; center=center)
+tn_split, Pl, Pr = tn_projected
+
+Pl_flat = reduce(vcat, Pl)
+Pr_flat = reduce(vcat, Pr)
+tn_projected_flat = mapreduce(vec, vcat, (tn_split, Pl_flat, Pr_flat))
+
+@show noncommoninds(tn_projected_flat...)
+@visualize *(tn_projected_flat...) contract=false
+
+@disable_warn_order begin
+  @show contract(tn_projected_flat)[] / contract(vec(tn))[]
+end
+
+# Uncombine the projector indices
+#tn_projected_uncombined = insert_gauge(tn_projected_flat, combiner_gauge)
+#projectors_uncombined = tn_split[(length(tn) + 1):end]
 
 

--- a/examples/tensor_network_tools/tensor_network_tools.jl
+++ b/examples/tensor_network_tools/tensor_network_tools.jl
@@ -10,7 +10,7 @@ end
 
 struct ITensorNetwork{T,L}
   data::Dict{T,ITensor} # Map tensor labels to tensors
-  tags::Dict{T,TagSet} # Map tensor labels to tags that categorize the tensors
+  tags::Dict{T,TagSet} # Map tensor labels to tags that categorize the tensors, such as boundary
   lattice::L
   out_boundary::Dict{T,T} # Represent links across boundaries
   in_boundary::Dict{T,T} # Represent links across boundaries

--- a/src/tensor_networks.jl
+++ b/src/tensor_networks.jl
@@ -105,7 +105,6 @@ end
 # A network of link indices for a HyperCubic lattice, with
 # no site indices.
 function inds_network(dims::Int...; linkdims, kwargs...)
-  #site_inds = Array{Index{typeof(linkdims)},length(dims)}(undef, dims)
   site_inds = fill(Index{typeof(linkdims)}[], dims)
   return inds_network(site_inds; linkdims=linkdims, kwargs...)
 end

--- a/src/tensor_networks.jl
+++ b/src/tensor_networks.jl
@@ -260,7 +260,6 @@ outlinkinds(tn) = filter_alllinkinds(<, tn)
 function split_links(H::Union{MPS,MPO}; split_tags=("" => ""), split_plevs=(0 => 1))
   left_tags, right_tags = split_tags
   left_plev, right_plev = split_plevs
-  #N = length(H)
   l = outlinkinds(H)
   Hsplit = copy(H)
   for bond in keys(l)
@@ -534,4 +533,144 @@ function insert_projectors(tn; center, projector_center=nothing, maxdim, cutoff)
   end
   return tn_split, projectors_left, projectors_right
 end
+
+function filterneighbors(f, tn, n)
+  neighbors_tn = keytype(tn)[]
+  tnₙ = tn[n]
+  for m in keys(tn)
+    if f(n, m) && hascommoninds(tnₙ, tn[m])
+      push!(neighbors_tn, m)
+    end
+  end
+  return neighbors_tn
+end
+neighbors(tn, n) = filterneighbors(≠, tn, n)
+inneighbors(tn, n) = filterneighbors(>, tn, n)
+outneighbors(tn, n) = filterneighbors(<, tn, n)
+
+function mapinds(f, ::typeof(linkinds), tn)
+  tn′ = copy(tn)
+  for n in keys(tn)
+    for nn in neighbors(tn, n)
+      commonindsₙ = commoninds(tn[n], tn[nn])
+      tn′[n] = replaceinds(tn′[n], commonindsₙ => f(commonindsₙ))
+    end
+  end
+  return tn′
+end
+
+ITensors.prime(::typeof(linkinds), tn, args...) = mapinds(x -> prime(x, args...), linkinds, tn)
+ITensors.addtags(::typeof(linkinds), tn, args...) = mapinds(x -> addtags(x, args...), linkinds, tn)
+
+# Return a dictionary from a site to a combiner
+function combiners(::typeof(linkinds), tn)
+  Cs = Dict(keys(tn) .=> (ITensor[] for _ in keys(tn)))
+  for n in keys(tn)
+    for nn in inneighbors(tn, n)
+      commonindsₙ = commoninds(tn[n], tn[nn])
+      C = combiner(commonindsₙ)
+      push!(Cs[n], C)
+      push!(Cs[nn], dag(C))
+    end
+  end
+  return Cs
+end
+
+function contraction_cache_top(tn, boundary_mps::Vector{MPS}, n)
+  tn_cache = fill(ITensor(1.0), size(tn))
+  for nrow in 1:size(tn, 1)
+    if nrow == n
+      tn_cache[nrow, :] .= boundary_mps[nrow]
+    elseif nrow > n
+      tn_cache[nrow, :] = tn[nrow, :]
+    end
+  end
+  return tn_cache
+end
+
+function contraction_cache_top(tn, boundary_mps::Vector{MPS})
+  tn_cache_top = Vector{typeof(tn)}(undef, length(boundary_mps))
+  for n in 1:length(boundary_mps)
+    tn_cache_top[n] = contraction_cache_top(tn, boundary_mps, n)
+  end
+  return tn_cache_top
+end
+
+function contraction_cache_bottom(tn, boundary_mps::Vector{MPS})
+  tn_top = rot180(tn)
+  tn_top = reverse(tn_top; dims=2)
+  boundary_mps_top = reverse(boundary_mps)
+  tn_cache_top = contraction_cache_top(tn_top, boundary_mps_top)
+  tn_cache = reverse.(tn_cache_top; dims=2)
+  tn_cache = rot180.(tn_cache)
+  return tn_cache
+end
+
+function contraction_cache_left(tn, boundary_mps::Vector{MPS})
+  tn_top = rotr90(tn)
+  tn_cache_top = contraction_cache_top(tn_top, boundary_mps)
+  tn_cache = rotl90.(tn_cache_top)
+  return tn_cache
+end
+
+function contraction_cache_right(tn, boundary_mps::Vector{MPS})
+  tn_bottom = rotr90(tn)
+  tn_cache_bottom = contraction_cache_bottom(tn_bottom, boundary_mps)
+  tn_cache = rotl90.(tn_cache_bottom)
+  return tn_cache
+end
+
+function contraction_cache(tn, boundary_mps)
+  cache_top = contraction_cache_top(tn, boundary_mps.top)
+  cache_bottom = contraction_cache_bottom(tn, boundary_mps.bottom)
+  cache_left = contraction_cache_left(tn, boundary_mps.left)
+  cache_right = contraction_cache_right(tn, boundary_mps.right)
+  return (top=cache_top, bottom=cache_bottom, left=cache_left, right=cache_right)
+end
+
+function insert_gauge(tn::NamedTuple, gauge)
+  return map(x -> insert_gauge.(x, (gauge,)), tn)
+end
+
+function insert_gauge(tn, gauge)
+  tn′ = copy(tn)
+  for n in keys(gauge)
+    for g in gauge[n]
+      if hascommoninds(tn′[n], g)
+        tn′[n] *= g
+      end
+    end
+  end
+  return tn′
+end
+
+function boundary_mps_top(tn)
+  return [MPS(tn[n][n, :]) for n in 1:length(tn)]
+end
+
+function boundary_mps_bottom(tn)
+  tn_top = rot180.(tn)
+  tn_top = reverse.(tn_top; dims=2)
+  boundary_mps = boundary_mps_top(tn_top)
+  return reverse(boundary_mps)
+end
+
+function boundary_mps_left(tn)
+  tn_top = rotr90.(tn)
+  return boundary_mps_top(tn_top)
+end
+
+function boundary_mps_right(tn)
+  tn_bottom = rotr90.(tn)
+  return boundary_mps_bottom(tn_bottom)
+end
+
+function boundary_mps(tn::NamedTuple)
+  _boundary_mps_top = boundary_mps_top(tn.top)
+  _boundary_mps_bottom = boundary_mps_bottom(tn.bottom)
+  _boundary_mps_left = boundary_mps_left(tn.left)
+  _boundary_mps_right = boundary_mps_right(tn.right)
+  return BoundaryMPS(top=_boundary_mps_top, bottom=_boundary_mps_bottom, left=_boundary_mps_left, right=_boundary_mps_right)
+end
+
 


### PR DESCRIPTION
Add approximate PEPS inner product contraction by inserting projectors determined from a boundary MPS-MPO contraction.