### PR TITLE
Contraction sequence backends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 DataGraphs = "b5a273c3-7e6c-41f6-98bd-8d7f1525a36a"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -280,9 +280,7 @@ julia> @visualize Z;
     ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
     ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 
-julia> using ITensors.ContractionSequenceOptimization
-
-julia> optimal_contraction_sequence(Z)
+julia> contraction_sequence(Z)
 2-element Vector{Vector}:
  [(1, 1), (2, 1)]
  Any[(1, 2), Any[(2, 2), [(1, 3), (2, 3)]]]

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -54,8 +54,7 @@ tn2 = ITensorNetwork(s; link_space=2)
 @visualize tn2;
 Z = prime(tn1; sites=[]) ⊗ tn2;
 @visualize Z;
-using ITensors.ContractionSequenceOptimization
-optimal_contraction_sequence(Z)
+contraction_sequence(Z)
 Z̃ = contract(Z, (1, 1) => (2, 1));
 @visualize Z̃;
 

--- a/examples/TTN/ttn_type.jl
+++ b/examples/TTN/ttn_type.jl
@@ -1,6 +1,5 @@
 using AbstractTrees
 using ITensors
-using ITensors.ContractionSequenceOptimization
 using ITensorNetworks
 using ITensorUnicodePlots
 
@@ -38,7 +37,7 @@ end
 
 @visualize Z
 
-sequence = optimal_contraction_sequence(Z)
+sequence = contraction_sequence(Z)
 
 @show sequence
 
@@ -101,11 +100,9 @@ for e in post_order_dfs_edges(ψ_ortho, root_vertex)
 end
 
 @show √(
-  contract(
-    norm_network(ψ_ortho); sequence=optimal_contraction_sequence(norm_network(ψ_ortho))
-  )[],
+  contract(norm_network(ψ_ortho); sequence=contraction_sequence(norm_network(ψ_ortho)))[]
 )
-@show √(contract(norm_network(ψ); sequence=optimal_contraction_sequence(norm_network(ψ)))[])
+@show √(contract(norm_network(ψ); sequence=contraction_sequence(norm_network(ψ)))[])
 @show norm(ψ_ortho[root_vertex])
 @show √(inner(ψ, ψ))
 @show √(inner(ψ_ortho, ψ_ortho))

--- a/examples/contraction_sequence/contraction_sequence.jl
+++ b/examples/contraction_sequence/contraction_sequence.jl
@@ -8,7 +8,7 @@ Random.seed!(1234)
 
 ITensors.disable_warn_order()
 
-dims = (2, 2)
+dims = (2, 3)
 g = named_grid(dims)
 s = siteinds("S=1/2", g)
 
@@ -22,19 +22,19 @@ tn = norm_network(ψ)
 # inner_sequence = reduce((x, y) -> [x, y], contract_edges)
 
 println("optimal")
-# seq_optimal = @time contraction_sequence(tn; alg="optimal")
+seq_optimal = @time contraction_sequence(tn; alg="optimal")
 
 using OMEinsumContractionOrders
 
 println("greedy")
-seq_greedy = @time contraction_sequence(Vector{ITensor}(tn); alg="greedy")
+seq_greedy = @time contraction_sequence(tn; alg="greedy")
 
 println("tree_sa")
-# seq_tree_sa = @time contraction_sequence(Vector{ITensor}(tn); alg="tree_sa")
+seq_tree_sa = @time contraction_sequence(tn; alg="tree_sa")
 
 println("sa_bipartite")
-seq_sa_bipartite = @time contraction_sequence(Vector{ITensor}(tn); alg="sa_bipartite")
+seq_sa_bipartite = @time contraction_sequence(tn; alg="sa_bipartite")
 
 println("kahypar_bipartite")
 using KaHyPar
-seq_kahypar_bipartite = @time contraction_sequence(Vector{ITensor}(tn); alg="kahypar_bipartite", sc_target=200)
+seq_kahypar_bipartite = @time contraction_sequence(tn; alg="kahypar_bipartite", sc_target=200)

--- a/examples/contraction_sequence/contraction_sequence.jl
+++ b/examples/contraction_sequence/contraction_sequence.jl
@@ -1,7 +1,5 @@
 using ITensors
 using ITensorNetworks
-using ITensorUnicodePlots
-using UnicodePlots
 using Random
 
 Random.seed!(1234)
@@ -28,6 +26,7 @@ using OMEinsumContractionOrders
 
 println("greedy")
 seq_greedy = @time contraction_sequence(tn; alg="greedy")
+res_greedy = @time contract(tn; alg=res_greedy)
 
 println("tree_sa")
 seq_tree_sa = @time contraction_sequence(tn; alg="tree_sa")

--- a/examples/contraction_sequence/contraction_sequence.jl
+++ b/examples/contraction_sequence/contraction_sequence.jl
@@ -8,7 +8,7 @@ Random.seed!(1234)
 
 ITensors.disable_warn_order()
 
-dims = (20, 20)
+dims = (2, 2)
 g = named_grid(dims)
 s = siteinds("S=1/2", g)
 

--- a/examples/contraction_sequence/contraction_sequence.jl
+++ b/examples/contraction_sequence/contraction_sequence.jl
@@ -35,6 +35,9 @@ seq_tree_sa = @time contraction_sequence(tn; alg="tree_sa")
 println("sa_bipartite")
 seq_sa_bipartite = @time contraction_sequence(tn; alg="sa_bipartite")
 
-println("kahypar_bipartite")
 using KaHyPar
-seq_kahypar_bipartite = @time contraction_sequence(tn; alg="kahypar_bipartite", sc_target=200)
+
+println("kahypar_bipartite")
+seq_kahypar_bipartite = @time contraction_sequence(
+  tn; alg="kahypar_bipartite", sc_target=200
+)

--- a/examples/contraction_sequence/contraction_sequence.jl
+++ b/examples/contraction_sequence/contraction_sequence.jl
@@ -1,0 +1,40 @@
+using ITensors
+using ITensorNetworks
+using ITensorUnicodePlots
+using UnicodePlots
+using Random
+
+Random.seed!(1234)
+
+ITensors.disable_warn_order()
+
+dims = (20, 20)
+g = named_grid(dims)
+s = siteinds("S=1/2", g)
+
+χ = 10
+ψ = randomITensorNetwork(s; link_space=χ)
+
+tn = norm_network(ψ)
+
+# Contraction sequence for exactly computing expectation values
+# contract_edges = map(t -> (1, t...), collect(keys(cartesian_to_linear(dims))))
+# inner_sequence = reduce((x, y) -> [x, y], contract_edges)
+
+println("optimal")
+# seq_optimal = @time contraction_sequence(tn; alg="optimal")
+
+using OMEinsumContractionOrders
+
+println("greedy")
+seq_greedy = @time contraction_sequence(Vector{ITensor}(tn); alg="greedy")
+
+println("tree_sa")
+# seq_tree_sa = @time contraction_sequence(Vector{ITensor}(tn); alg="tree_sa")
+
+println("sa_bipartite")
+seq_sa_bipartite = @time contraction_sequence(Vector{ITensor}(tn); alg="sa_bipartite")
+
+println("kahypar_bipartite")
+using KaHyPar
+seq_kahypar_bipartite = @time contraction_sequence(Vector{ITensor}(tn); alg="kahypar_bipartite", sc_target=200)

--- a/examples/mps.jl
+++ b/examples/mps.jl
@@ -30,7 +30,7 @@ e = edge_data(is)
 @visualize ψψ
 
 # quasi-optimal contraction sequence
-sequence = optimal_contraction_sequence(ψψ)
+sequence = contraction_sequence(ψψ)
 
 print_tree(sequence)
 

--- a/examples/peps/ising_tebd.jl
+++ b/examples/peps/ising_tebd.jl
@@ -29,7 +29,9 @@ s_dmrg = [only(s[v]) for v in vertices(s)]
 H_dmrg = MPO(ℋ_dmrg, s_dmrg)
 ψ_dmrg_init = MPS(s_dmrg, j -> "↑")
 @show inner(ψ_dmrg_init', H_dmrg, ψ_dmrg_init)
-E_dmrg, ψ_dmrg = dmrg(H_dmrg, ψ_dmrg_init; nsweeps=20, maxdim=[fill(10, 10); 20], cutoff=1e-8)
+E_dmrg, ψ_dmrg = dmrg(
+  H_dmrg, ψ_dmrg_init; nsweeps=20, maxdim=[fill(10, 10); 20], cutoff=1e-8
+)
 @show E_dmrg
 Z_dmrg = reshape(expect(ψ_dmrg, "Z"), dims)
 
@@ -61,14 +63,18 @@ contract_edges = map(t -> (1, t...), collect(keys(cartesian_to_linear(dims))))
 inner_sequence = reduce((x, y) -> [x, y], contract_edges)
 
 println("\nFirst run TEBD without orthogonalization")
-ψ = @time tebd(group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho=false, print_frequency=1)
+ψ = @time tebd(
+  group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho=false, print_frequency=1
+)
 
 println("\nMeasure energy expectation value")
 E = @time expect(ℋ, ψ; sequence=inner_sequence)
 @show E
 
 println("\nThen run TEBD with orthogonalization (more accurate)")
-ψ = @time tebd(group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho, print_frequency=1)
+ψ = @time tebd(
+  group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho, print_frequency=1
+)
 
 println("\nMeasure energy expectation value")
 E = @time expect(ℋ, ψ; sequence=inner_sequence)

--- a/src/ITensorNetworks.jl
+++ b/src/ITensorNetworks.jl
@@ -130,9 +130,15 @@ include(joinpath("treetensornetwork", "treetensornetwork.jl"))
 include("exports.jl")
 
 function __init__()
-  @require KaHyPar="2a6221f6-aa48-11e9-3542-2d9e0ef01880" include(joinpath("requires", "kahypar.jl"))
-  @require Metis="2679e427-3c69-5b7f-982b-ece356f1e94b" include(joinpath("requires", "metis.jl"))
-  @require OMEinsumContractionOrders="6f22d1fd-8eed-4bb7-9776-e7d684900715" include(joinpath("requires", "omeinsumcontractionorders.jl"))
+  @require KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880" include(
+    joinpath("requires", "kahypar.jl")
+  )
+  @require Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b" include(
+    joinpath("requires", "metis.jl")
+  )
+  @require OMEinsumContractionOrders = "6f22d1fd-8eed-4bb7-9776-e7d684900715" include(
+    joinpath("requires", "omeinsumcontractionorders.jl")
+  )
 end
 
 end

--- a/src/ITensorNetworks.jl
+++ b/src/ITensorNetworks.jl
@@ -2,6 +2,7 @@ module ITensorNetworks
 
 using DataGraphs
 using Dictionaries
+using DocStringExtensions
 using Graphs
 using ITensors
 using ITensors.ContractionSequenceOptimization
@@ -13,7 +14,7 @@ using SplitApplyCombine
 using Suppressor
 
 # TODO: export from ITensors
-using ITensors: commontags
+using ITensors: commontags, @Algorithm_str, Algorithm
 
 using Graphs: AbstractEdge, AbstractGraph, Graph, add_edge!
 using MultiDimDictionaries: IndexType, SliceIndex
@@ -118,6 +119,7 @@ include("indsnetwork.jl")
 include("opsum.jl") # Required IndsNetwork
 include("sitetype.jl")
 include("abstractitensornetwork.jl")
+include("contraction_sequences.jl")
 include("apply.jl")
 include("expect.jl")
 include("models.jl")
@@ -130,6 +132,7 @@ include("exports.jl")
 function __init__()
   @require KaHyPar="2a6221f6-aa48-11e9-3542-2d9e0ef01880" include(joinpath("requires", "kahypar.jl"))
   @require Metis="2679e427-3c69-5b7f-982b-ece356f1e94b" include(joinpath("requires", "metis.jl"))
+  @require OMEinsumContractionOrders="6f22d1fd-8eed-4bb7-9776-e7d684900715" include(joinpath("requires", "omeinsumcontractionorders.jl"))
 end
 
 end

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -430,14 +430,19 @@ function flattened_inner_network(ϕ::AbstractITensorNetwork, ψ::AbstractITensor
   return tn
 end
 
-function contract_inner(ϕ::AbstractITensorNetwork, ψ::AbstractITensorNetwork; sequence=nothing)
+function contract_inner(
+  ϕ::AbstractITensorNetwork,
+  ψ::AbstractITensorNetwork;
+  sequence=nothing,
+  contraction_sequence_kwargs=(;),
+)
   tn = inner(prime(ϕ; sites=[]), ψ)
   # TODO: convert to an IndsNetwork and compute the contraction sequence
   for v in vertices(ψ)
     tn = contract(tn, (2, v...) => (1, v...))
   end
   if isnothing(sequence)
-    sequence = optimal_contraction_sequence(tn)
+    sequence = contraction_sequence(tn; contraction_sequence_kwargs...)
   end
   return contract(tn; sequence)[]
 end

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -380,12 +380,6 @@ function Base.:*(c::Number, ψ::AbstractITensorNetwork)
   return cψ
 end
 
-function optimal_contraction_sequence(tn::AbstractITensorNetwork)
-  seq_linear_index = optimal_contraction_sequence(Vector{ITensor}(tn))
-  # TODO: use Functors.fmap
-  return deepmap(n -> vertices(tn)[n], seq_linear_index)
-end
-
 # TODO: should this make sure that internal indices
 # don't clash?
 function hvncat(

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -1,4 +1,6 @@
-function ITensors.apply(o::ITensor, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false)
+function ITensors.apply(
+  o::ITensor, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false
+)
   ψ = copy(ψ)
   v⃗ = neighbor_vertices(ψ, o)
   if length(v⃗) == 1
@@ -19,7 +21,9 @@ function ITensors.apply(o::ITensor, ψ::AbstractITensorNetwork; cutoff, maxdim, 
       ψ = orthogonalize(ψ, v⃗[1])
     end
     oψᵥ = apply(o, ψ[v⃗[1]] * ψ[v⃗[2]])
-    ψᵥ₁, ψᵥ₂ = factorize(oψᵥ, inds(ψ[v⃗[1]]); cutoff, maxdim, tags=ITensorNetworks.edge_tag(e))
+    ψᵥ₁, ψᵥ₂ = factorize(
+      oψᵥ, inds(ψ[v⃗[1]]); cutoff, maxdim, tags=ITensorNetworks.edge_tag(e)
+    )
     if normalize
       ψᵥ₁ ./= norm(ψᵥ₁)
       ψᵥ₂ ./= norm(ψᵥ₂)
@@ -34,7 +38,14 @@ function ITensors.apply(o::ITensor, ψ::AbstractITensorNetwork; cutoff, maxdim, 
   return ψ
 end
 
-function ITensors.apply(o⃗::Vector{ITensor}, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false)
+function ITensors.apply(
+  o⃗::Vector{ITensor},
+  ψ::AbstractITensorNetwork;
+  cutoff,
+  maxdim,
+  normalize=false,
+  ortho=false,
+)
   o⃗ψ = ψ
   for oᵢ in o⃗
     o⃗ψ = apply(oᵢ, o⃗ψ; cutoff, maxdim, normalize, ortho)
@@ -42,11 +53,16 @@ function ITensors.apply(o⃗::Vector{ITensor}, ψ::AbstractITensorNetwork; cutof
   return o⃗ψ
 end
 
-function ITensors.apply(o⃗::Scaled, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false)
-  return maybe_real(Ops.coefficient(o⃗)) * apply(Ops.argument(o⃗), ψ; cutoff, maxdim, normalize, ortho)
+function ITensors.apply(
+  o⃗::Scaled, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false
+)
+  return maybe_real(Ops.coefficient(o⃗)) *
+         apply(Ops.argument(o⃗), ψ; cutoff, maxdim, normalize, ortho)
 end
 
-function ITensors.apply(o⃗::Prod, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false)
+function ITensors.apply(
+  o⃗::Prod, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false
+)
   o⃗ψ = ψ
   for oᵢ in o⃗
     o⃗ψ = apply(oᵢ, o⃗ψ; cutoff, maxdim, normalize, ortho)
@@ -54,6 +70,8 @@ function ITensors.apply(o⃗::Prod, ψ::AbstractITensorNetwork; cutoff, maxdim, 
   return o⃗ψ
 end
 
-function ITensors.apply(o::Op, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false)
+function ITensors.apply(
+  o::Op, ψ::AbstractITensorNetwork; cutoff, maxdim, normalize=false, ortho=false
+)
   return apply(ITensor(o, siteinds(ψ)), ψ; cutoff, maxdim, normalize, ortho)
 end

--- a/src/contraction_sequences.jl
+++ b/src/contraction_sequences.jl
@@ -16,30 +16,106 @@ function contraction_sequence_requires_error(module_name, algorithm)
   return "Module `$(module_name)` not found, please type `using $(module_name)` before using the \"$(algorithm)\" contraction sequence backend!"
 end
 
+"""
+    GreedyMethod(; method=MinSpaceOut(), nrepeat=10)
+
+The fast but poor greedy optimizer. Input arguments are:
+
+* `method` is `MinSpaceDiff()` or `MinSpaceOut`.
+    * `MinSpaceOut` choose one of the contraction that produces a minimum output tensor size,
+    * `MinSpaceDiff` choose one of the contraction that decrease the space most.
+* `nrepeat` is the number of repeatition, returns the best contraction order.
+"""
 function contraction_sequence(::Algorithm"greedy", tn::Vector{ITensor}; kwargs...)
   if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
     error(contraction_sequence_requires_error("OMEinsumContractionOrders", "greedy"))
   end
-  return contraction_sequence(OMEinsumContractionOrders.GreedyMethod(; kwargs...), tn)
+  return optimize_contraction_sequence(
+    tn; optimizer=OMEinsumContractionOrders.GreedyMethod(; kwargs...)
+  )
 end
 
+"""
+    TreeSA(; sc_target=20, βs=collect(0.01:0.05:15), ntrials=10, niters=50,
+             sc_weight=1.0, rw_weight=0.2, initializer=:greedy, greedy_config=GreedyMethod(; nrepeat=1))
+
+Optimize the einsum contraction pattern using the simulated annealing on tensor expression tree.
+
+* `sc_target` is the target space complexity,
+* `ntrials`, `βs` and `niters` are annealing parameters, doing `ntrials` indepedent annealings, each has inverse tempteratures specified by `βs`, in each temperature, do `niters` updates of the tree.
+* `sc_weight` is the relative importance factor of space complexity in the loss compared with the time complexity.
+* `rw_weight` is the relative importance factor of memory read and write in the loss compared with the time complexity.
+* `initializer` specifies how to determine the initial configuration, it can be `:greedy` or `:random`. If it is using `:greedy` method to generate the initial configuration, it also uses two extra arguments `greedy_method` and `greedy_nrepeat`.
+* `nslices` is the number of sliced legs, default is 0.
+* `fixed_slices` is a vector of sliced legs, default is `[]`.
+
+### References
+* [Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits](https://arxiv.org/abs/2108.05665)
+"""
 function contraction_sequence(::Algorithm"tree_sa", tn; kwargs...)
   if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
     error(contraction_sequence_requires_error("OMEinsumContractionOrders", "tree_sa"))
   end
-  return contraction_sequence(OMEinsumContractionOrders.TreeSA(; kwargs...), tn)
+  return optimize_contraction_sequence(
+    tn; optimizer=OMEinsumContractionOrders.TreeSA(; kwargs...)
+  )
 end
 
+"""
+    SABipartite(; sc_target=25, ntrials=50, βs=0.1:0.2:15.0, niters=1000
+                  max_group_size=40, greedy_config=GreedyMethod(), initializer=:random)
+
+Optimize the einsum code contraction order using the Simulated Annealing bipartition + Greedy approach.
+This program first recursively cuts the tensors into several groups using simulated annealing,
+with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
+Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
+
+* `size_dict`, a dictionary that specifies leg dimensions,
+* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
+* `max_group_size` is the maximum size that allowed to used greedy search,
+* `βs` is a list of inverse temperature `1/T`,
+* `niters` is the number of iteration in each temperature,
+* `ntrials` is the number of repetition (with different random seeds),
+* `greedy_config` configures the greedy method,
+* `initializer`, the partition configuration initializer, one can choose `:random` or `:greedy` (slow but better).
+
+### References
+* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
+"""
 function contraction_sequence(::Algorithm"sa_bipartite", tn; kwargs...)
   if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
     error(contraction_sequence_requires_error("OMEinsumContractionOrders", "sa_bipartite"))
   end
-  return contraction_sequence(OMEinsumContractionOrders.SABipartite(; kwargs...), tn)
+  return optimize_contraction_sequence(
+    tn; optimizer=OMEinsumContractionOrders.SABipartite(; kwargs...)
+  )
 end
 
+"""
+    KaHyParBipartite(; sc_target, imbalances=collect(0.0:0.005:0.8),
+                       max_group_size=40, greedy_config=GreedyMethod())
+
+Optimize the einsum code contraction order using the KaHyPar + Greedy approach.
+This program first recursively cuts the tensors into several groups using KaHyPar,
+with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
+Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
+
+* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
+* `imbalances` is a KaHyPar parameter that controls the group sizes in hierarchical bipartition,
+* `max_group_size` is the maximum size that allowed to used greedy search,
+* `greedy_config` is a greedy optimizer.
+
+### References
+* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
+* [Simulating the Sycamore quantum supremacy circuits](https://arxiv.org/abs/2103.03074)
+"""
 function contraction_sequence(::Algorithm"kahypar_bipartite", tn; kwargs...)
   if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
-    error(contraction_sequence_requires_error("OMEinsumContractionOrders", "kahypar_bipartite"))
+    error(
+      contraction_sequence_requires_error("OMEinsumContractionOrders", "kahypar_bipartite")
+    )
   end
-  return contraction_sequence(OMEinsumContractionOrders.KaHyParBipartite(; kwargs...), tn)
+  return optimize_contraction_sequence(
+    tn; optimizer=OMEinsumContractionOrders.KaHyParBipartite(; kwargs...)
+  )
 end

--- a/src/contraction_sequences.jl
+++ b/src/contraction_sequences.jl
@@ -1,0 +1,45 @@
+function contraction_sequence(tn::Vector{ITensor}; alg="optimal", kwargs...)
+  return contraction_sequence(Algorithm(alg), tn; kwargs...)
+end
+
+function contraction_sequence(tn::AbstractITensorNetwork; kwargs...)
+  seq_linear_index = contraction_sequence(Vector{ITensor}(tn); kwargs...)
+  # TODO: use Functors.fmap
+  return deepmap(n -> vertices(tn)[n], seq_linear_index)
+end
+
+function contraction_sequence(::Algorithm"optimal", tn::Vector{ITensor})
+  return optimal_contraction_sequence(tn)
+end
+
+function contraction_sequence_requires_error(module_name, algorithm)
+  return "Module `$(module_name)` not found, please type `using $(module_name)` before using the \"$(algorithm)\" contraction sequence backend!"
+end
+
+function contraction_sequence(::Algorithm"greedy", tn::Vector{ITensor}; kwargs...)
+  if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
+    error(contraction_sequence_requires_error("OMEinsumContractionOrders", "greedy"))
+  end
+  return contraction_sequence(OMEinsumContractionOrders.GreedyMethod(; kwargs...), tn)
+end
+
+function contraction_sequence(::Algorithm"tree_sa", tn; kwargs...)
+  if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
+    error(contraction_sequence_requires_error("OMEinsumContractionOrders", "tree_sa"))
+  end
+  return contraction_sequence(OMEinsumContractionOrders.TreeSA(; kwargs...), tn)
+end
+
+function contraction_sequence(::Algorithm"sa_bipartite", tn; kwargs...)
+  if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
+    error(contraction_sequence_requires_error("OMEinsumContractionOrders", "sa_bipartite"))
+  end
+  return contraction_sequence(OMEinsumContractionOrders.SABipartite(; kwargs...), tn)
+end
+
+function contraction_sequence(::Algorithm"kahypar_bipartite", tn; kwargs...)
+  if !isdefined(@__MODULE__, :OMEinsumContractionOrders)
+    error(contraction_sequence_requires_error("OMEinsumContractionOrders", "kahypar_bipartite"))
+  end
+  return contraction_sequence(OMEinsumContractionOrders.KaHyParBipartite(; kwargs...), tn)
+end

--- a/src/expect.jl
+++ b/src/expect.jl
@@ -1,8 +1,15 @@
-function ITensors.expect(op::String, ψ::AbstractITensorNetwork; cutoff=nothing, maxdim=nothing, ortho=false, sequence=nothing)
+function ITensors.expect(
+  op::String,
+  ψ::AbstractITensorNetwork;
+  cutoff=nothing,
+  maxdim=nothing,
+  ortho=false,
+  sequence=nothing,
+)
   s = siteinds(ψ)
   res = Dictionary(vertices(ψ), Vector{Float64}(undef, nv(ψ)))
   if isnothing(sequence)
-    sequence = optimal_contraction_sequence(flattened_inner_network(ψ, ψ))
+    sequence = contraction_sequence(flattened_inner_network(ψ, ψ))
   end
   normψ² = norm2(ψ; sequence)
   for v in vertices(ψ)
@@ -13,11 +20,18 @@ function ITensors.expect(op::String, ψ::AbstractITensorNetwork; cutoff=nothing,
   return res
 end
 
-function ITensors.expect(ℋ::OpSum, ψ::AbstractITensorNetwork; cutoff=nothing, maxdim=nothing, ortho=false, sequence=nothing)
+function ITensors.expect(
+  ℋ::OpSum,
+  ψ::AbstractITensorNetwork;
+  cutoff=nothing,
+  maxdim=nothing,
+  ortho=false,
+  sequence=nothing,
+)
   s = siteinds(ψ)
   # h⃗ = Vector{ITensor}(ℋ, s)
   if isnothing(sequence)
-    sequence = optimal_contraction_sequence(flattened_inner_network(ψ, ψ))
+    sequence = contraction_sequence(flattened_inner_network(ψ, ψ))
   end
   h⃗ψ = [apply(hᵢ, ψ; cutoff, maxdim, ortho) for hᵢ in ITensors.terms(ℋ)]
   ψhᵢψ = [contract_inner(ψ, hᵢψ; sequence) for hᵢψ in h⃗ψ]
@@ -26,6 +40,13 @@ function ITensors.expect(ℋ::OpSum, ψ::AbstractITensorNetwork; cutoff=nothing,
   return ψh⃗ψ / ψψ
 end
 
-function ITensors.expect(opsum_sum::Sum{<:OpSum}, ψ::AbstractITensorNetwork; cutoff=nothing, maxdim=nothing, ortho=true, sequence=nothing)
+function ITensors.expect(
+  opsum_sum::Sum{<:OpSum},
+  ψ::AbstractITensorNetwork;
+  cutoff=nothing,
+  maxdim=nothing,
+  ortho=true,
+  sequence=nothing,
+)
   return expect(sum(Ops.terms(opsum_sum)), ψ; cutoff, maxdim, ortho, sequence)
 end

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -45,12 +45,6 @@ export NamedDimGraph,
 export DataGraph, vertex_data, edge_data, underlying_graph
 
 #
-# ITensors
-#
-
-export optimal_contraction_sequence
-
-#
 # ITensorNetworks
 #
 

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -60,6 +60,7 @@ export IndsNetwork
 # itensornetwork.jl
 export AbstractITensorNetwork,
   ITensorNetwork,
+  randomITensorNetwork,
   ⊗,
   itensors,
   tensor_product,
@@ -69,6 +70,8 @@ export AbstractITensorNetwork,
   inner_network,
   norm_network,
   reverse_bfs_edges,
+  # contraction_sequences.jl
+  contraction_sequence,
   # utils.jl
   cartesian_to_linear,
   # namedgraphs.jl

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -48,8 +48,6 @@ import ITensors:
   # dag
   dag
 
-import ITensors.ContractionSequenceOptimization: optimal_contraction_sequence
-
 using ITensors.ContractionSequenceOptimization: deepmap
 
 import ITensors.ITensorVisualizationCore: visualize

--- a/src/namedgraphs.jl
+++ b/src/namedgraphs.jl
@@ -1,5 +1,7 @@
 NamedGraphs.NamedDimGraph(vertices::Vector) = NamedDimGraph(tuple.(vertices))
-NamedGraphs.NamedDimGraph(vertices::Vector{<:Tuple}) = NamedDimGraph(Graph(length(vertices)); vertices)
+function NamedGraphs.NamedDimGraph(vertices::Vector{<:Tuple})
+  return NamedDimGraph(Graph(length(vertices)); vertices)
+end
 
 function rename_vertices(e::AbstractEdge, name_map::Dictionary)
   return typeof(e)(name_map[src(e)], name_map[dst(e)])

--- a/src/requires/omeinsumcontractionorders.jl
+++ b/src/requires/omeinsumcontractionorders.jl
@@ -283,5 +283,5 @@ Then finds the contraction order inside each group with the greedy search algori
 * [Simulating the Sycamore quantum supremacy circuits](https://arxiv.org/abs/2103.03074)
 """
 function contraction_sequence(alg::OMEinsumContractionOrders.CodeOptimizer, tensors::ITensorList)
-  return optimize_contraction(tensors; optimizer=alg)
+  return optimize_contraction_sequence(tensors; optimizer=alg)
 end

--- a/src/requires/omeinsumcontractionorders.jl
+++ b/src/requires/omeinsumcontractionorders.jl
@@ -1,0 +1,269 @@
+# using OMEinsumContractionOrders
+#using OMEinsumContractionOrders: CodeOptimizer
+
+# Port OMEinsumContractionOrders to ITensors
+# Slicing is not supported, because it might require extra work to slice an `ITensor` correctly.
+
+const ITensorList = Union{Vector{<:ITensor},Tuple{Vararg{<:ITensor}}}
+
+"""
+$(TYPEDEF)
+    ITensorContractionTree(args) -> ITensorContractionTree
+Define a tensor network with its contraction order specified by a tree structure.
+In this network, each index in this tensor network must appear either twice or once.
+The input `args` is a Vector of [`ITensor`](@ref) or another layer of Vector.
+This data type can be automatically generated from [`optimize_contraction`](@ref) function.
+### Fields
+$(TYPEDFIELDS)
+### Examples
+The following code creates a tensor network and evaluates it in a sequencial order.
+```jldoctest
+julia> using ITensors, ITensorContractionOrders
+julia> i, j, k, l = Index(4), Index(5), Index(6), Index(7);
+julia> x, y, z = randomITensor(i, j), randomITensor(j, k), randomITensor(k, l);
+julia> it = ITensorContractionTree([[x, y] ,z]);
+julia> itensor_list = ITensorContractionOrders.flatten(it);  # convert this tensor network to a Vector of ITensors
+julia> evaluate(it) ≈ foldl(*, itensor_list)
+true
+```
+"""
+struct ITensorContractionTree{IT}
+    args::Vector{Union{ITensorContractionTree, ITensor}}
+    iy::Vector{Index{IT}}   # the output labels, note: this is type unstable
+end
+ITensors.inds(it::ITensorContractionTree) = (it.iy...,)
+
+function ITensorContractionTree(args)::ITensorContractionTree
+    args = Union{ITensorContractionTree, ITensor}[arg isa Union{AbstractVector, Tuple} ? ITensorContractionTree(arg) : arg for arg in args]
+    # get output labels
+    # NOTE: here we assume the output index id has `Int` type
+    labels = collect.(Index{Int}, ITensors.inds.(args))
+    return ITensorContractionTree(args, infer_output(labels))
+end
+
+"""
+    flatten(it::ITensorContractionTree) -> Vector
+Convert an [`ITensorContractionTree`](@ref) to a Vector of [`ITensor`](@ref).
+"""
+flatten(it::ITensorContractionTree) = flatten!(it, ITensor[])
+function flatten!(it::ITensorContractionTree, lst)
+    for arg in it.args
+        if arg isa ITensor
+            push!(lst, arg)
+        else
+            flatten!(arg, lst)
+        end
+    end
+    return lst
+end
+
+# Contract and evaluate an itensor network.
+"""
+$(TYPEDSIGNATURES)
+"""
+evaluate(it::ITensorContractionTree)::ITensor = foldl(*, evaluate.(it.args))
+evaluate(it::ITensor) = it
+
+############################ Port to OMEinsumContractionOrders #######################
+getid(index::Index) = index
+getids(A::ITensor) = Index{Int}[getid(x) for x in ITensors.inds(A)]
+getids(A::ITensorContractionTree) = collect(Index{Int}, getid.(ITensors.inds(A)))
+function rootcode(it::ITensorContractionTree)
+    ixs = [getids(A) for A in it.args]
+    return OMEinsumContractionOrders.EinCode(ixs, it.iy)
+end
+
+function update_size_index_dict!(size_dict::Dict{Index{IT}}, index_dict::Dict{Index{IT}}, tensor::ITensor) where IT
+    for ind in ITensors.inds(tensor)
+        size_dict[getid(ind)] = ind.space
+        index_dict[getid(ind)] = ind
+    end
+    return size_dict
+end
+
+# decorate means converting the raw contraction pattern to ITensorContractionTree.
+# `tensors` is the original input tensor list.
+function decorate(net::OMEinsumContractionOrders.NestedEinsum, tensors::ITensorList)
+    if OMEinsumContractionOrders.isleaf(net)
+        return tensors[net.tensorindex]
+    else
+        return ITensorContractionTree(decorate.(net.args, Ref(tensors)))
+    end
+end
+
+# get a (labels, size_dict) representation of a ITensorContractionTree
+function rawcode(tensors::ITensorList)
+    # we use id as the label
+    indsAs = [collect(Index{Int}, ITensors.inds(A)) for A in tensors]
+    ixs = [getids(x) for x in tensors]
+    unique_labels = unique(vcat(indsAs...))
+    size_dict = Dict([getid(x)=>x.space for x in unique_labels])
+    index_dict = Dict([getid(x)=>x for x in unique_labels])
+    return OMEinsumContractionOrders.EinCode(ixs, getid.(infer_output(indsAs))), size_dict, index_dict
+end
+
+# infer the output tensor labels
+function infer_output(inputs::AbstractVector{<:AbstractVector{Index{IT}}}) where IT
+    indslist = vcat(inputs...)
+    # get output indices
+    iy = Index{IT}[]
+    for l in indslist
+        c = count(==(l), indslist)
+        if c == 1
+            push!(iy, l)
+        elseif c !== 2
+            error("Each index in a tensor network must appear at most twice!")
+        end
+    end
+    return iy
+end
+
+function rawcode(net::ITensorContractionTree{IT}) where IT
+    size_dict = Dict{Index{IT},Int}()
+    index_dict = Dict{Index{IT},Index{Int}}()
+    r = rawcode!(net, size_dict, index_dict)
+    return r, size_dict, index_dict
+end
+function rawcode!(net::ITensorContractionTree{IT}, size_dict::Dict{Index{IT}}, index_dict::Dict{Index{IT}}, index_counter=Base.RefValue(0)) where IT
+    args = map(net.args) do s
+        if s isa ITensor
+            update_size_index_dict!(size_dict, index_dict, s)
+            OMEinsumContractionOrders.NestedEinsum{Index{IT}}(index_counter[] += 1)
+        else  # ITensorContractionTree
+            scode = rawcode!(s, size_dict, index_dict, index_counter)
+            # no need to update size, size is only updated on the leaves.
+            scode
+        end
+    end
+    return OMEinsumContractionOrders.NestedEinsum(args, rootcode(net))
+end
+
+"""
+$(TYPEDSIGNATURES)
+Optimize the contraction order of a tensor network specified as a vector tensors.
+Returns a [`ITensorContractionTree`](@ref) instance, which can be evaluated with the [`evaluate`](@ref) function.
+### Examples
+```jldoctest
+julia> using ITensors, ITensorContractionOrders
+julia> i, j, k, l = Index(4), Index(5), Index(6), Index(7);
+julia> x, y, z = randomITensor(i, j), randomITensor(j, k), randomITensor(k, l);
+julia> net = optimize_contraction([x, y, z]; optimizer=TreeSA());
+```
+"""
+function optimize_contraction(tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA())::ITensorContractionTree
+    r, size_dict, index_dict = rawcode(tensors)
+    # merge vectors can speed up contraction order finding
+    # optimize the permutation of tensors is set to true
+    res = OMEinsumContractionOrders.optimize_code(r, size_dict, optimizer, OMEinsumContractionOrders.MergeVectors(), true)
+    if res isa OMEinsumContractionOrders.SlicedEinsum   # slicing is not supported!
+        if length(res.slicing) != 0
+            @warn "Slicing is not yet supported by `ITensors`, removing slices..."
+        end
+        res = res.eins
+    end
+    return decorate(res, tensors)
+end
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.peak_memory(net::ITensorContractionTree)::Int = peak_memory(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.flop(net::ITensorContractionTree)::Int = flop(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.timespacereadwrite_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.timespace_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)[1:2]
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.contraction_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.contraction_complexity(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+    label_elimination_order(net::ITensorContractionTree) -> Vector
+"""
+function OMEinsumContractionOrders.label_elimination_order(net::ITensorContractionTree)
+    r, size_dict, index_dict = rawcode(net)
+    return getindex.(Ref(index_dict), label_elimination_order(r))
+end
+
+"""
+    ITensorNetworks.contraction_sequence interface for OMEinsumContractionOrders
+
+    GreedyMethod(; method=MinSpaceOut(), nrepeat=10)
+
+The fast but poor greedy optimizer. Input arguments are:
+
+* `method` is `MinSpaceDiff()` or `MinSpaceOut`.
+    * `MinSpaceOut` choose one of the contraction that produces a minimum output tensor size,
+    * `MinSpaceDiff` choose one of the contraction that decrease the space most.
+* `nrepeat` is the number of repeatition, returns the best contraction order.
+
+
+    TreeSA(; sc_target=20, βs=collect(0.01:0.05:15), ntrials=10, niters=50,
+             sc_weight=1.0, rw_weight=0.2, initializer=:greedy, greedy_config=GreedyMethod(; nrepeat=1))
+
+Optimize the einsum contraction pattern using the simulated annealing on tensor expression tree.
+
+* `sc_target` is the target space complexity,
+* `ntrials`, `βs` and `niters` are annealing parameters, doing `ntrials` indepedent annealings, each has inverse tempteratures specified by `βs`, in each temperature, do `niters` updates of the tree.
+* `sc_weight` is the relative importance factor of space complexity in the loss compared with the time complexity.
+* `rw_weight` is the relative importance factor of memory read and write in the loss compared with the time complexity.
+* `initializer` specifies how to determine the initial configuration, it can be `:greedy` or `:random`. If it is using `:greedy` method to generate the initial configuration, it also uses two extra arguments `greedy_method` and `greedy_nrepeat`.
+* `nslices` is the number of sliced legs, default is 0.
+* `fixed_slices` is a vector of sliced legs, default is `[]`.
+
+### References
+* [Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits](https://arxiv.org/abs/2108.05665)
+
+    SABipartite(; sc_target=25, ntrials=50, βs=0.1:0.2:15.0, niters=1000
+                  max_group_size=40, greedy_config=GreedyMethod(), initializer=:random)
+
+Optimize the einsum code contraction order using the Simulated Annealing bipartition + Greedy approach.
+This program first recursively cuts the tensors into several groups using simulated annealing,
+with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
+Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
+
+* `size_dict`, a dictionary that specifies leg dimensions,
+* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
+* `max_group_size` is the maximum size that allowed to used greedy search,
+* `βs` is a list of inverse temperature `1/T`,
+* `niters` is the number of iteration in each temperature,
+* `ntrials` is the number of repetition (with different random seeds),
+* `greedy_config` configures the greedy method,
+* `initializer`, the partition configuration initializer, one can choose `:random` or `:greedy` (slow but better).
+
+### References
+* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
+
+    KaHyParBipartite(; sc_target, imbalances=collect(0.0:0.005:0.8),
+                       max_group_size=40, greedy_config=GreedyMethod())
+
+Optimize the einsum code contraction order using the KaHyPar + Greedy approach.
+This program first recursively cuts the tensors into several groups using KaHyPar,
+with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
+Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
+
+* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
+* `imbalances` is a KaHyPar parameter that controls the group sizes in hierarchical bipartition,
+* `max_group_size` is the maximum size that allowed to used greedy search,
+* `greedy_config` is a greedy optimizer.
+
+### References
+* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
+* [Simulating the Sycamore quantum supremacy circuits](https://arxiv.org/abs/2103.03074)
+"""
+function contraction_sequence(alg::OMEinsumContractionOrders.CodeOptimizer, tensors::ITensorList)
+  return optimize_contraction(tensors; optimizer=alg)
+end

--- a/src/requires/omeinsumcontractionorders.jl
+++ b/src/requires/omeinsumcontractionorders.jl
@@ -1,147 +1,44 @@
-# using OMEinsumContractionOrders
-#using OMEinsumContractionOrders: CodeOptimizer
-
-# Port OMEinsumContractionOrders to ITensors
+# OMEinsumContractionOrders wrapper for ITensors
 # Slicing is not supported, because it might require extra work to slice an `ITensor` correctly.
 
 const ITensorList = Union{Vector{<:ITensor},Tuple{Vararg{<:ITensor}}}
 
-"""
-$(TYPEDEF)
-    ITensorContractionTree(args) -> ITensorContractionTree
-Define a tensor network with its contraction order specified by a tree structure.
-In this network, each index in this tensor network must appear either twice or once.
-The input `args` is a Vector of [`ITensor`](@ref) or another layer of Vector.
-This data type can be automatically generated from [`optimize_contraction`](@ref) function.
-### Fields
-$(TYPEDFIELDS)
-### Examples
-The following code creates a tensor network and evaluates it in a sequencial order.
-```jldoctest
-julia> using ITensors, ITensorContractionOrders
-julia> i, j, k, l = Index(4), Index(5), Index(6), Index(7);
-julia> x, y, z = randomITensor(i, j), randomITensor(j, k), randomITensor(k, l);
-julia> it = ITensorContractionTree([[x, y] ,z]);
-julia> itensor_list = ITensorContractionOrders.flatten(it);  # convert this tensor network to a Vector of ITensors
-julia> evaluate(it) ≈ foldl(*, itensor_list)
-true
-```
-"""
-struct ITensorContractionTree{IT}
-    args::Vector{Union{ITensorContractionTree, ITensor}}
-    iy::Vector{Index{IT}}   # the output labels, note: this is type unstable
-end
-ITensors.inds(it::ITensorContractionTree) = (it.iy...,)
-
-function ITensorContractionTree(args)::ITensorContractionTree
-    args = Union{ITensorContractionTree, ITensor}[arg isa Union{AbstractVector, Tuple} ? ITensorContractionTree(arg) : arg for arg in args]
-    # get output labels
-    # NOTE: here we assume the output index id has `Int` type
-    labels = collect.(Index{Int}, ITensors.inds.(args))
-    return ITensorContractionTree(args, infer_output(labels))
-end
-
-"""
-    flatten(it::ITensorContractionTree) -> Vector
-Convert an [`ITensorContractionTree`](@ref) to a Vector of [`ITensor`](@ref).
-"""
-flatten(it::ITensorContractionTree) = flatten!(it, ITensor[])
-function flatten!(it::ITensorContractionTree, lst)
-    for arg in it.args
-        if arg isa ITensor
-            push!(lst, arg)
-        else
-            flatten!(arg, lst)
-        end
-    end
-    return lst
-end
-
-# Contract and evaluate an itensor network.
-"""
-$(TYPEDSIGNATURES)
-"""
-evaluate(it::ITensorContractionTree)::ITensor = foldl(*, evaluate.(it.args))
-evaluate(it::ITensor) = it
-
-############################ Port to OMEinsumContractionOrders #######################
 getid(index::Index) = index
 getids(A::ITensor) = Index{Int}[getid(x) for x in ITensors.inds(A)]
-getids(A::ITensorContractionTree) = collect(Index{Int}, getid.(ITensors.inds(A)))
-function rootcode(it::ITensorContractionTree)
-    ixs = [getids(A) for A in it.args]
-    return OMEinsumContractionOrders.EinCode(ixs, it.iy)
-end
-
-function update_size_index_dict!(size_dict::Dict{Index{IT}}, index_dict::Dict{Index{IT}}, tensor::ITensor) where IT
-    for ind in ITensors.inds(tensor)
-        size_dict[getid(ind)] = ind.space
-        index_dict[getid(ind)] = ind
-    end
-    return size_dict
-end
-
-# decorate means converting the raw contraction pattern to ITensorContractionTree.
-# `tensors` is the original input tensor list.
-function decorate(net::OMEinsumContractionOrders.NestedEinsum, tensors::ITensorList)
-    if OMEinsumContractionOrders.isleaf(net)
-        return tensors[net.tensorindex]
-    else
-        return ITensorContractionTree(decorate.(net.args, Ref(tensors)))
-    end
-end
-
-# get a (labels, size_dict) representation of a ITensorContractionTree
-function rawcode(tensors::ITensorList)
-    # we use id as the label
-    indsAs = [collect(Index{Int}, ITensors.inds(A)) for A in tensors]
-    ixs = [getids(x) for x in tensors]
-    unique_labels = unique(vcat(indsAs...))
-    size_dict = Dict([getid(x)=>x.space for x in unique_labels])
-    index_dict = Dict([getid(x)=>x for x in unique_labels])
-    return OMEinsumContractionOrders.EinCode(ixs, getid.(infer_output(indsAs))), size_dict, index_dict
-end
 
 # infer the output tensor labels
-function infer_output(inputs::AbstractVector{<:AbstractVector{Index{IT}}}) where IT
-    indslist = vcat(inputs...)
-    # get output indices
-    iy = Index{IT}[]
-    for l in indslist
-        c = count(==(l), indslist)
-        if c == 1
-            push!(iy, l)
-        elseif c !== 2
-            error("Each index in a tensor network must appear at most twice!")
-        end
+function infer_output(inputs::AbstractVector{<:AbstractVector{Index{IT}}}) where {IT}
+  indslist = vcat(inputs...)
+  # get output indices
+  iy = Index{IT}[]
+  for l in indslist
+    c = count(==(l), indslist)
+    if c == 1
+      push!(iy, l)
+    elseif c !== 2
+      error("Each index in a tensor network must appear at most twice!")
     end
-    return iy
+  end
+  return iy
 end
 
-function rawcode(net::ITensorContractionTree{IT}) where IT
-    size_dict = Dict{Index{IT},Int}()
-    index_dict = Dict{Index{IT},Index{Int}}()
-    r = rawcode!(net, size_dict, index_dict)
-    return r, size_dict, index_dict
-end
-function rawcode!(net::ITensorContractionTree{IT}, size_dict::Dict{Index{IT}}, index_dict::Dict{Index{IT}}, index_counter=Base.RefValue(0)) where IT
-    args = map(net.args) do s
-        if s isa ITensor
-            update_size_index_dict!(size_dict, index_dict, s)
-            OMEinsumContractionOrders.NestedEinsum{Index{IT}}(index_counter[] += 1)
-        else  # ITensorContractionTree
-            scode = rawcode!(s, size_dict, index_dict, index_counter)
-            # no need to update size, size is only updated on the leaves.
-            scode
-        end
-    end
-    return OMEinsumContractionOrders.NestedEinsum(args, rootcode(net))
+# get a (labels, size_dict) representation of a collection of ITensors
+function rawcode(tensors::ITensorList)
+  # we use id as the label
+  indsAs = [collect(Index{Int}, ITensors.inds(A)) for A in tensors]
+  ixs = [getids(x) for x in tensors]
+  unique_labels = unique(vcat(indsAs...))
+  size_dict = Dict([getid(x) => x.space for x in unique_labels])
+  index_dict = Dict([getid(x) => x for x in unique_labels])
+  return OMEinsumContractionOrders.EinCode(ixs, getid.(infer_output(indsAs))),
+  size_dict,
+  index_dict
 end
 
 """
 $(TYPEDSIGNATURES)
 Optimize the contraction order of a tensor network specified as a vector tensors.
-Returns a [`ITensorContractionTree`](@ref) instance, which can be evaluated with the [`evaluate`](@ref) function.
+Returns a [`NestedEinsum`](@ref) instance.
 ### Examples
 ```jldoctest
 julia> using ITensors, ITensorContractionOrders
@@ -150,23 +47,30 @@ julia> x, y, z = randomITensor(i, j), randomITensor(j, k), randomITensor(k, l);
 julia> net = optimize_contraction([x, y, z]; optimizer=TreeSA());
 ```
 """
-function optimize_contraction(tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA())
-    r, size_dict, index_dict = rawcode(tensors)
-    # merge vectors can speed up contraction order finding
-    # optimize the permutation of tensors is set to true
-    res = OMEinsumContractionOrders.optimize_code(r, size_dict, optimizer, OMEinsumContractionOrders.MergeVectors(), true)
-    if res isa OMEinsumContractionOrders.SlicedEinsum   # slicing is not supported!
-        if length(res.slicing) != 0
-            @warn "Slicing is not yet supported by `ITensors`, removing slices..."
-        end
-        res = res.eins
+function optimize_contraction_nested_einsum(
+  tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA()
+)
+  r, size_dict, index_dict = rawcode(tensors)
+  # merge vectors can speed up contraction order finding
+  # optimize the permutation of tensors is set to true
+  res = OMEinsumContractionOrders.optimize_code(
+    r, size_dict, optimizer, OMEinsumContractionOrders.MergeVectors(), true
+  )
+  if res isa OMEinsumContractionOrders.SlicedEinsum   # slicing is not supported!
+    if length(res.slicing) != 0
+      @warn "Slicing is not yet supported by `ITensors`, removing slices..."
     end
-    return res
+    res = res.eins
+  end
+  return res
 end
 
-# decorate means converting the raw contraction pattern to ITensorContractionTree.
-# `tensors` is the original input tensor list.
-function convert_to_contraction_sequence(net::OMEinsumContractionOrders.NestedEinsum, tensor_indices)
+"""
+Convert NestedEinsum to contraction sequence, such as `[[1, 2], [3, 4]]`.
+"""
+function convert_to_contraction_sequence(
+  net::OMEinsumContractionOrders.NestedEinsum, tensor_indices
+)
   if OMEinsumContractionOrders.isleaf(net)
     return tensor_indices[net.tensorindex]
   else
@@ -177,111 +81,9 @@ end
 """
 Convert the result of `optimize_contraction` to a contraction sequence.
 """
-function optimize_contraction_sequence(tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA())
-  res = optimize_contraction(tensors; optimizer)
+function optimize_contraction_sequence(
+  tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA()
+)
+  res = optimize_contraction_nested_einsum(tensors; optimizer)
   return convert_to_contraction_sequence(res, 1:length(tensors))
-end
-
-"""
-$(TYPEDSIGNATURES)
-"""
-OMEinsumContractionOrders.peak_memory(net::ITensorContractionTree)::Int = peak_memory(rawcode(net)[1:2]...)
-
-"""
-$(TYPEDSIGNATURES)
-"""
-OMEinsumContractionOrders.flop(net::ITensorContractionTree)::Int = flop(rawcode(net)[1:2]...)
-
-"""
-$(TYPEDSIGNATURES)
-"""
-OMEinsumContractionOrders.timespacereadwrite_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)
-
-"""
-$(TYPEDSIGNATURES)
-"""
-OMEinsumContractionOrders.timespace_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)[1:2]
-
-"""
-$(TYPEDSIGNATURES)
-"""
-OMEinsumContractionOrders.contraction_complexity(net::ITensorContractionTree) = OMEinsumContractionOrders.contraction_complexity(rawcode(net)[1:2]...)
-
-"""
-$(TYPEDSIGNATURES)
-    label_elimination_order(net::ITensorContractionTree) -> Vector
-"""
-function OMEinsumContractionOrders.label_elimination_order(net::ITensorContractionTree)
-    r, size_dict, index_dict = rawcode(net)
-    return getindex.(Ref(index_dict), label_elimination_order(r))
-end
-
-"""
-    ITensorNetworks.contraction_sequence interface for OMEinsumContractionOrders
-
-    GreedyMethod(; method=MinSpaceOut(), nrepeat=10)
-
-The fast but poor greedy optimizer. Input arguments are:
-
-* `method` is `MinSpaceDiff()` or `MinSpaceOut`.
-    * `MinSpaceOut` choose one of the contraction that produces a minimum output tensor size,
-    * `MinSpaceDiff` choose one of the contraction that decrease the space most.
-* `nrepeat` is the number of repeatition, returns the best contraction order.
-
-
-    TreeSA(; sc_target=20, βs=collect(0.01:0.05:15), ntrials=10, niters=50,
-             sc_weight=1.0, rw_weight=0.2, initializer=:greedy, greedy_config=GreedyMethod(; nrepeat=1))
-
-Optimize the einsum contraction pattern using the simulated annealing on tensor expression tree.
-
-* `sc_target` is the target space complexity,
-* `ntrials`, `βs` and `niters` are annealing parameters, doing `ntrials` indepedent annealings, each has inverse tempteratures specified by `βs`, in each temperature, do `niters` updates of the tree.
-* `sc_weight` is the relative importance factor of space complexity in the loss compared with the time complexity.
-* `rw_weight` is the relative importance factor of memory read and write in the loss compared with the time complexity.
-* `initializer` specifies how to determine the initial configuration, it can be `:greedy` or `:random`. If it is using `:greedy` method to generate the initial configuration, it also uses two extra arguments `greedy_method` and `greedy_nrepeat`.
-* `nslices` is the number of sliced legs, default is 0.
-* `fixed_slices` is a vector of sliced legs, default is `[]`.
-
-### References
-* [Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits](https://arxiv.org/abs/2108.05665)
-
-    SABipartite(; sc_target=25, ntrials=50, βs=0.1:0.2:15.0, niters=1000
-                  max_group_size=40, greedy_config=GreedyMethod(), initializer=:random)
-
-Optimize the einsum code contraction order using the Simulated Annealing bipartition + Greedy approach.
-This program first recursively cuts the tensors into several groups using simulated annealing,
-with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
-Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
-
-* `size_dict`, a dictionary that specifies leg dimensions,
-* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
-* `max_group_size` is the maximum size that allowed to used greedy search,
-* `βs` is a list of inverse temperature `1/T`,
-* `niters` is the number of iteration in each temperature,
-* `ntrials` is the number of repetition (with different random seeds),
-* `greedy_config` configures the greedy method,
-* `initializer`, the partition configuration initializer, one can choose `:random` or `:greedy` (slow but better).
-
-### References
-* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
-
-    KaHyParBipartite(; sc_target, imbalances=collect(0.0:0.005:0.8),
-                       max_group_size=40, greedy_config=GreedyMethod())
-
-Optimize the einsum code contraction order using the KaHyPar + Greedy approach.
-This program first recursively cuts the tensors into several groups using KaHyPar,
-with maximum group size specifed by `max_group_size` and maximum space complexity specified by `sc_target`,
-Then finds the contraction order inside each group with the greedy search algorithm. Other arguments are:
-
-* `sc_target` is the target space complexity, defined as `log2(number of elements in the largest tensor)`,
-* `imbalances` is a KaHyPar parameter that controls the group sizes in hierarchical bipartition,
-* `max_group_size` is the maximum size that allowed to used greedy search,
-* `greedy_config` is a greedy optimizer.
-
-### References
-* [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
-* [Simulating the Sycamore quantum supremacy circuits](https://arxiv.org/abs/2103.03074)
-"""
-function contraction_sequence(alg::OMEinsumContractionOrders.CodeOptimizer, tensors::ITensorList)
-  return optimize_contraction_sequence(tensors; optimizer=alg)
 end

--- a/src/requires/omeinsumcontractionorders.jl
+++ b/src/requires/omeinsumcontractionorders.jl
@@ -3,10 +3,12 @@
 
 const ITensorList = Union{Vector{<:ITensor},Tuple{Vararg{<:ITensor}}}
 
+# TODO: Replace with `inds(A::ITensor)` or `collect(inds(A::ITensor))`
 getid(index::Index) = index
 getids(A::ITensor) = Index{Int}[getid(x) for x in ITensors.inds(A)]
 
 # infer the output tensor labels
+# TODO: Use `symdiff` instead.
 function infer_output(inputs::AbstractVector{<:AbstractVector{Index{IT}}}) where {IT}
   indslist = vcat(inputs...)
   # get output indices
@@ -69,12 +71,12 @@ end
 Convert NestedEinsum to contraction sequence, such as `[[1, 2], [3, 4]]`.
 """
 function convert_to_contraction_sequence(
-  net::OMEinsumContractionOrders.NestedEinsum, tensor_indices
+  net::OMEinsumContractionOrders.NestedEinsum
 )
   if OMEinsumContractionOrders.isleaf(net)
-    return tensor_indices[net.tensorindex]
+    return net.tensorindex
   else
-    return convert_to_contraction_sequence.(net.args, Ref(tensor_indices))
+    return convert_to_contraction_sequence.(net.args)
   end
 end
 
@@ -85,5 +87,5 @@ function optimize_contraction_sequence(
   tensors::ITensorList; optimizer::OMEinsumContractionOrders.CodeOptimizer=TreeSA()
 )
   res = optimize_contraction_nested_einsum(tensors; optimizer)
-  return convert_to_contraction_sequence(res, 1:length(tensors))
+  return convert_to_contraction_sequence(res)
 end

--- a/src/requires/omeinsumcontractionorders_itensorcontractiontree.jl
+++ b/src/requires/omeinsumcontractionorders_itensorcontractiontree.jl
@@ -1,0 +1,154 @@
+"""
+$(TYPEDEF)
+    ITensorContractionTree(args) -> ITensorContractionTree
+Define a tensor network with its contraction order specified by a tree structure.
+In this network, each index in this tensor network must appear either twice or once.
+The input `args` is a Vector of [`ITensor`](@ref) or another layer of Vector.
+This data type can be automatically generated from [`optimize_contraction`](@ref) function.
+### Fields
+$(TYPEDFIELDS)
+### Examples
+The following code creates a tensor network and evaluates it in a sequencial order.
+```jldoctest
+julia> using ITensors, ITensorContractionOrders
+julia> i, j, k, l = Index(4), Index(5), Index(6), Index(7);
+julia> x, y, z = randomITensor(i, j), randomITensor(j, k), randomITensor(k, l);
+julia> it = ITensorContractionTree([[x, y] ,z]);
+julia> itensor_list = ITensorContractionOrders.flatten(it);  # convert this tensor network to a Vector of ITensors
+julia> evaluate(it) ≈ foldl(*, itensor_list)
+true
+```
+"""
+struct ITensorContractionTree{IT}
+  args::Vector{Union{ITensorContractionTree,ITensor}}
+  iy::Vector{Index{IT}}   # the output labels, note: this is type unstable
+end
+ITensors.inds(it::ITensorContractionTree) = (it.iy...,)
+
+function ITensorContractionTree(args)::ITensorContractionTree
+  args = Union{ITensorContractionTree,ITensor}[
+    arg isa Union{AbstractVector,Tuple} ? ITensorContractionTree(arg) : arg for arg in args
+  ]
+  # get output labels
+  # NOTE: here we assume the output index id has `Int` type
+  labels = collect.(Index{Int}, ITensors.inds.(args))
+  return ITensorContractionTree(args, infer_output(labels))
+end
+
+"""
+    flatten(it::ITensorContractionTree) -> Vector
+Convert an [`ITensorContractionTree`](@ref) to a Vector of [`ITensor`](@ref).
+"""
+flatten(it::ITensorContractionTree) = flatten!(it, ITensor[])
+function flatten!(it::ITensorContractionTree, lst)
+  for arg in it.args
+    if arg isa ITensor
+      push!(lst, arg)
+    else
+      flatten!(arg, lst)
+    end
+  end
+  return lst
+end
+
+# Contract and evaluate an itensor network.
+"""
+$(TYPEDSIGNATURES)
+"""
+evaluate(it::ITensorContractionTree)::ITensor = foldl(*, evaluate.(it.args))
+evaluate(it::ITensor) = it
+
+getids(A::ITensorContractionTree) = collect(Index{Int}, getid.(ITensors.inds(A)))
+function rootcode(it::ITensorContractionTree)
+  ixs = [getids(A) for A in it.args]
+  return OMEinsumContractionOrders.EinCode(ixs, it.iy)
+end
+
+# decorate means converting the raw contraction pattern to ITensorContractionTree.
+# `tensors` is the original input tensor list.
+function decorate(net::OMEinsumContractionOrders.NestedEinsum, tensors::ITensorList)
+  if OMEinsumContractionOrders.isleaf(net)
+    return tensors[net.tensorindex]
+  else
+    return ITensorContractionTree(decorate.(net.args, Ref(tensors)))
+  end
+end
+
+function update_size_index_dict!(
+  size_dict::Dict{Index{IT}}, index_dict::Dict{Index{IT}}, tensor::ITensor
+) where {IT}
+  for ind in ITensors.inds(tensor)
+    size_dict[getid(ind)] = ind.space
+    index_dict[getid(ind)] = ind
+  end
+  return size_dict
+end
+
+function rawcode!(
+  net::ITensorContractionTree{IT},
+  size_dict::Dict{Index{IT}},
+  index_dict::Dict{Index{IT}},
+  index_counter=Base.RefValue(0),
+) where {IT}
+  args = map(net.args) do s
+    if s isa ITensor
+      update_size_index_dict!(size_dict, index_dict, s)
+      OMEinsumContractionOrders.NestedEinsum{Index{IT}}(index_counter[] += 1)
+    else  # ITensorContractionTree
+      scode = rawcode!(s, size_dict, index_dict, index_counter)
+      # no need to update size, size is only updated on the leaves.
+      scode
+    end
+  end
+  return OMEinsumContractionOrders.NestedEinsum(args, rootcode(net))
+end
+function rawcode(net::ITensorContractionTree{IT}) where {IT}
+  size_dict = Dict{Index{IT},Int}()
+  index_dict = Dict{Index{IT},Index{Int}}()
+  r = rawcode!(net, size_dict, index_dict)
+  return r, size_dict, index_dict
+end
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.peak_memory(net::ITensorContractionTree)::Int =
+  peak_memory(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+"""
+OMEinsumContractionOrders.flop(net::ITensorContractionTree)::Int =
+  flop(rawcode(net)[1:2]...)
+
+"""
+$(TYPEDSIGNATURES)
+"""
+function OMEinsumContractionOrders.timespacereadwrite_complexity(
+  net::ITensorContractionTree
+)
+  return OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+"""
+function OMEinsumContractionOrders.timespace_complexity(net::ITensorContractionTree)
+  return OMEinsumContractionOrders.timespacereadwrite_complexity(rawcode(net)[1:2]...)[1:2]
+end
+
+"""
+$(TYPEDSIGNATURES)
+"""
+function OMEinsumContractionOrders.contraction_complexity(net::ITensorContractionTree)
+  return OMEinsumContractionOrders.contraction_complexity(rawcode(net)[1:2]...)
+end
+
+"""
+$(TYPEDSIGNATURES)
+    label_elimination_order(net::ITensorContractionTree) -> Vector
+"""
+function OMEinsumContractionOrders.label_elimination_order(net::ITensorContractionTree)
+  r, size_dict, index_dict = rawcode(net)
+  return getindex.(Ref(index_dict), label_elimination_order(r))
+end

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -1,4 +1,6 @@
-function tebd(ℋ::Sum, ψ::AbstractITensorNetwork; β, Δβ, maxdim, cutoff, print_frequency=10, ortho=false)
+function tebd(
+  ℋ::Sum, ψ::AbstractITensorNetwork; β, Δβ, maxdim, cutoff, print_frequency=10, ortho=false
+)
   𝒰 = exp(-Δβ * ℋ; alg=Trotter{2}())
   # Imaginary time evolution terms
   s = siteinds(ψ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Random
 using Test
 
 include("test_tebd.jl")
+include("test_contraction_sequence.jl")
 
 @testset "ITensorNetworks.jl" begin
   @testset "Basics" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,8 +40,8 @@ include("test_tebd.jl")
     g = named_grid(dims)
     s = siteinds("S=1/2", g)
     ψ = ITensorNetwork(s, v -> "↑")
-    tn = inner(ψ, sim(dag(ψ), sites=[]))
-    tn_2 = contract(tn,  (2, 1, 2) => (1, 1, 2))
+    tn = inner(ψ, sim(dag(ψ); sites=[]))
+    tn_2 = contract(tn, (2, 1, 2) => (1, 1, 2))
     @test !has_vertex(tn_2, (2, 1, 2))
     @test tn_2[1, 1, 2] ≈ tn[2, 1, 2] * tn[1, 1, 2]
   end
@@ -52,7 +52,7 @@ include("test_tebd.jl")
     s = siteinds("S=1/2", g)
     ψ = ITensorNetwork(s, v -> "↑")
     rem_vertex!(ψ, (1, 2))
-    tn = inner(ψ, sim(dag(ψ), sites=[]))
+    tn = inner(ψ, sim(dag(ψ); sites=[]))
     @test !has_vertex(tn, (1, 1, 2))
     @test !has_vertex(tn, (2, 1, 2))
     @test has_vertex(tn, (1, 1, 1))
@@ -67,7 +67,7 @@ include("test_tebd.jl")
 
   ## @test inner_tn isa ITensorNetwork
 
-  ## sequence = optimal_contraction_sequence(inner_tn)
+  ## sequence = contraction_sequence(inner_tn)
 
   ## @test sequence isa Vector
 

--- a/test/test_contraction_sequence.jl
+++ b/test/test_contraction_sequence.jl
@@ -1,0 +1,32 @@
+using ITensors
+using ITensorNetworks
+using OMEinsumContractionOrders
+using KaHyPar
+using Random
+using Test
+
+Random.seed!(1234)
+
+ITensors.disable_warn_order()
+
+@testset "contraction_sequence" begin
+  dims = (2, 3)
+  g = named_grid(dims)
+  s = siteinds("S=1/2", g)
+  χ = 10
+  ψ = randomITensorNetwork(s; link_space=χ)
+  tn = norm_network(ψ)
+  seq_optimal = contraction_sequence(tn; alg="optimal")
+  res_optimal = contract(tn; sequence=seq_optimal)[]
+  seq_greedy = contraction_sequence(tn; alg="greedy")
+  res_greedy = contract(tn; sequence=seq_greedy)[]
+  seq_tree_sa = contraction_sequence(tn; alg="tree_sa")
+  res_tree_sa = contract(tn; sequence=seq_tree_sa)[]
+  seq_sa_bipartite = contraction_sequence(tn; alg="sa_bipartite")
+  res_sa_bipartite = contract(tn; sequence=seq_sa_bipartite)[]
+  seq_kahypar_bipartite = contraction_sequence(
+    tn; alg="kahypar_bipartite", sc_target=200
+  )
+  res_kahypar_bipartite = contract(tn; sequence=seq_kahypar_bipartite)[]
+  @test res_optimal ≈ res_greedy ≈ res_tree_sa ≈ res_sa_bipartite ≈ res_kahypar_bipartite
+end

--- a/test/test_tebd.jl
+++ b/test/test_tebd.jl
@@ -21,7 +21,9 @@ ITensors.disable_warn_order()
   s_dmrg = [only(s[v]) for v in vertices(s)]
   H_dmrg = MPO(ℋ_dmrg, s_dmrg)
   ψ_dmrg_init = MPS(s_dmrg, j -> "↑")
-  E_dmrg, ψ_dmrg = dmrg(H_dmrg, ψ_dmrg_init; nsweeps=20, maxdim=[fill(10, 10); 20], cutoff=1e-8, outputlevel=0)
+  E_dmrg, ψ_dmrg = dmrg(
+    H_dmrg, ψ_dmrg_init; nsweeps=20, maxdim=[fill(10, 10); 20], cutoff=1e-8, outputlevel=0
+  )
 
   #
   # PEPS TEBD optimization
@@ -37,11 +39,29 @@ ITensors.disable_warn_order()
 
   ψ_init = ITensorNetwork(s, v -> "↑")
   E0 = expect(ℋ, ψ_init; sequence=inner_sequence)
-  ψ = tebd(group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho=false, print_frequency=typemax(Int))
+  ψ = tebd(
+    group_terms(ℋ, g),
+    ψ_init;
+    β,
+    Δβ,
+    cutoff=1e-8,
+    maxdim=χ,
+    ortho=false,
+    print_frequency=typemax(Int),
+  )
   E1 = expect(ℋ, ψ; sequence=inner_sequence)
-  ψ = tebd(group_terms(ℋ, g), ψ_init; β, Δβ, cutoff=1e-8, maxdim=χ, ortho=true, print_frequency=typemax(Int))
+  ψ = tebd(
+    group_terms(ℋ, g),
+    ψ_init;
+    β,
+    Δβ,
+    cutoff=1e-8,
+    maxdim=χ,
+    ortho=true,
+    print_frequency=typemax(Int),
+  )
   E2 = expect(ℋ, ψ; sequence=inner_sequence)
-  
+
   @test E2 < E1 < E0
   @test E2 ≈ E_dmrg rtol = 1e-5
 end


### PR DESCRIPTION
This adds a variety of more efficient but potentially sub-optimal contraction sequence algorithms from [OMEinsumContractionOrders.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl), based on the wrapper @GiggleLiu wrote in [ITensorContractionOrders.jl](https://github.yanqishui.work/GiggleLiu/ITensorContractionOrders.jl).

It is based around a single function `contraction_sequence(tn::ITensorNetwork; alg="optimal")` where `alg="optimal"` chooses the optimal but exponentially scaling algorithm implemented in `ITensors.jl` (in the submodule `ITensors.ContractionSequenceOptimization`), and this PR provides the alternative backends `"greedy"`, `"tree_sa"`, `"sa_bipartite"`, and `"kahypar_bipartite"` when `OMEinsumContractionOrders.jl` is loaded with `using OMEinsumContractionOrders`.

You can perform the contraction as follows:
```julia
seq = contraction_sequence(tn)
res = contract(tn; sequence=seq)
```

Note that this is slightly breaking since it removes the function `optimal_contraction_sequence(tn::ITensorNetwork)` in favor of the new interface `contraction_sequence(tn::ITensorNetwork)`, where the default is `alg="optimal"`.

Also note that it also accepts `contraction_sequence(tn::Vector{ITensor})`, in which case it outputs a sequence with integer vertices.