### PR TITLE
Added More Flexible Partitioning and Subgraph Creation

### DIFF
--- a/src/beliefpropagation.jl
+++ b/src/beliefpropagation.jl
@@ -1,5 +1,5 @@
 function construct_initial_mts(tn::ITensorNetwork, nvertices_per_subgraph::Integer; subgraph_kwargs=(;), kwargs...)
-  return construct_initial_mts(tn, subgraphs(tn, nvertices_per_subgraph; subgraph_kwargs...); kwargs...)
+  return construct_initial_mts(tn, create_subgraphs(tn, nvertices_per_subgraph; subgraph_kwargs...); kwargs...)
 end
 
 function construct_initial_mts(tn::ITensorNetwork, subgraphs::DataGraph; init)


### PR DESCRIPTION
This is in response to issue #28 .

I have updated `subgraphs.jl` to allow for increased capability. 

1) The `subgraph` function (which creates a data graph which merges certain vertices of an underlying graph g) has been replaced by `create_subgraphs` which has 3 versions. One where you specify the #vertices_per_subgraph you want, one where you specify the #subgraphs you want and one where you explicitly provide the vertex groupings you want as a dictionary.
2) This function is aided by the `partition_vertices` function which forms vertex groupings (backending onto the `partition` function from KaHyPar or Metis) based on either a specified nvertices_per_group or ngroups. 