### PR TITLE
Fix `contract` tests

### DIFF
--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -154,7 +154,7 @@ function inner(
   ψ::AbstractTTN;
   root_vertex=default_root_vertex(ϕ, ψ),
 )
-  ϕᴴ = sim(dag(ψ); sites=[])
+  ϕᴴ = sim(dag(ϕ); sites=[])
   ψ = sim(ψ; sites=[])
   ϕψ = ϕᴴ ⊗ ψ
   # TODO: find the largest tensor and use it as

--- a/src/treetensornetworks/solvers/contract.jl
+++ b/src/treetensornetworks/solvers/contract.jl
@@ -18,7 +18,6 @@ function contract(
   nsweeps=1,
   kwargs...,
 )
-  @warn """`contract(::AbstractTTN, ::AbstractTTN; alg="fit")` is currently broken, you will likely get incorrect results."""
   n = nv(tn1)
   n != nv(tn2) && throw(
     DimensionMismatch("Number of sites operator ($n) and state ($(nv(tn2))) do not match"),

--- a/test/test_treetensornetworks/test_solvers/test_contract.jl
+++ b/test/test_treetensornetworks/test_solvers/test_contract.jl
@@ -22,8 +22,8 @@ using Test
   H = mpo(os, s)
 
   # Test basic usage with default parameters
-  Hpsi = apply(H, psi; alg="fit")
-  @test_broken inner(psi, Hpsi) ≈ inner(psi', H, psi) atol = 1E-5
+  Hpsi = apply(H, psi; alg="fit", init=psi')
+  @test inner(psi, Hpsi) ≈ inner(psi', H, psi) atol = 1E-5
 
   #
   # Change "top" indices of MPO to be a different set
@@ -35,21 +35,19 @@ using Test
     psit[j] *= delta(s[j], t[j])
   end
 
-  # Test with nsweeps=2
-  Hpsi = apply(H, psi; alg="fit", nsweeps=2)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
+  # Test with nsweeps=3
+  Hpsi = apply(H, psi; alg="fit", nsweeps=3)
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with less good initial guess MPS not equal to psi
-  psi_guess = copy(psi)
-  psi_guess = truncate(psi_guess; maxdim=2)
+  psi_guess = truncate(psi; maxdim=2)
   Hpsi = apply(H, psi; alg="fit", nsweeps=4, init_state=psi_guess)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with nsite=1
-  Hpsi_guess = @test_broken apply(H, psi; alg="naive", cutoff=1E-4)
-  # Hpsi = apply(H, psi; alg="fit", init_state=Hpsi_guess, nsite=1, nsweeps=2)
-  Hpsi = apply(H, psi; alg="fit", nsite=1, nsweeps=2)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4
+  Hpsi_guess = random_mps(t; internal_inds_space=32)
+  Hpsi = apply(H, psi; alg="fit", init=Hpsi_guess, nsite=1, nsweeps=4)
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4
 end
 
 @testset "Contract TTN" begin
@@ -65,7 +63,7 @@ end
 
   # Test basic usage with default parameters
   Hpsi = apply(H, psi; alg="fit")
-  @test_broken inner(psi, Hpsi) ≈ inner(psi', H, psi) atol = 1E-5 # broken when rebasing local draft on remote main, fix this
+  @test inner(psi, Hpsi) ≈ inner(psi', H, psi) atol = 1E-5
 
   #
   # Change "top" indices of TTN to be a different set
@@ -77,17 +75,17 @@ end
 
   # Test with nsweeps=2
   Hpsi = apply(H, psi; alg="fit", nsweeps=2)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5 # broken when rebasing local draft on remote main, fix this
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with less good initial guess MPS not equal to psi
-  psi_guess = copy(psi)
-  psi_guess = truncate(psi_guess; maxdim=2)
-  Hpsi = apply(H, psi; alg="fit", nsweeps=4, init_state=psi_guess)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5 # broken when rebasing local draft on remote main, fix this
+  Hpsi_guess = truncate(psit; maxdim=2)
+  Hpsi = apply(H, psi; alg="fit", nsweeps=4, init=Hpsi_guess)
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-5
 
   # Test with nsite=1
-  Hpsi = apply(H, psi; alg="fit", nsite=1, nsweeps=2)
-  @test_broken inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4 # broken when rebasing local draft on remote main, fix this
+  Hpsi_guess = random_ttn(t; link_space=4)
+  Hpsi = apply(H, psi; alg="fit", nsite=1, nsweeps=4, init=Hpsi_guess)
+  @test inner(psit, Hpsi) ≈ inner(psit, H, psi) atol = 1E-4
 end
 
 nothing


### PR DESCRIPTION
Fixes tests for `contract(::AbstractTTN, ::AbstractTTN)` by fixing a bug in `inner(::AbstractTTN, ::AbstractTTN)` and changing the initial states used in the tests. Aside from the bug making it it seem like the algorithm failed when it actually didn't, the updated behavior for the initial state always starts from a product state by default. So the `nsite=2` case needs more sweeps to be able to grow the bond dimension enough, and the `nsite=1` case couldn't work without explicitly supplying an initial state with a nontrivial bond dimension.