### PR TITLE
Let binary tree partition support the disconnected tensor network

### DIFF
--- a/src/binary_tree_partition.jl
+++ b/src/binary_tree_partition.jl
@@ -5,20 +5,40 @@ function _binary_partition(tn::ITensorNetwork, source_inds::Vector{<:Index})
   tn = map_data(t -> replaceinds(t, external_inds => external_sim_ind), tn; edges=[])
   tn_wo_deltas = rename_vertices(v -> v[1], subgraph(v -> v[2] == 1, tn))
   deltas = Vector{ITensor}(subgraph(v -> v[2] == 2, tn))
+  scalars = rename_vertices(v -> v[1], subgraph(v -> v[2] == 3, tn))
   new_deltas = [
     delta(external_inds[i], external_sim_ind[i]) for i in 1:length(external_inds)
   ]
   deltas = [deltas..., new_deltas...]
-  tn = disjoint_union(tn_wo_deltas, ITensorNetwork(deltas))
+  tn = disjoint_union(tn_wo_deltas, ITensorNetwork(deltas), scalars)
   p1, p2 = _mincut_partition_maxweightoutinds(
     tn, source_inds, setdiff(external_inds, source_inds)
   )
   source_tn = _contract_deltas(subgraph(tn, p1))
   remain_tn = _contract_deltas(subgraph(tn, p2))
+  outinds_source = noncommoninds(Vector{ITensor}(source_tn)...)
+  outinds_remain = noncommoninds(Vector{ITensor}(remain_tn)...)
+  common_inds = intersect(outinds_source, outinds_remain)
   @assert (
     length(external_inds) ==
-    length(noncommoninds(Vector{ITensor}(source_tn)..., Vector{ITensor}(remain_tn)...))
+    length(union(outinds_source, outinds_remain)) - length(common_inds)
   )
+  # We want the output two tns be connected to each other, so that the output
+  # of `binary_tree_partition` is a partition with a binary tree structure.
+  # Below we check if `source_tn` and `remain_tn` are connected, if not adding
+  # each tn a scalar tensor to force them to be connected.
+  if common_inds == []
+    @info "_binary_partition outputs are not connected"
+    ind = Index(1, "unit_scalar_ind")
+    t1 = ITensor([1.0], ind)
+    t2 = ITensor([1.0], ind)
+    v1 = (nv(scalars) + 1, 3)
+    v2 = (nv(scalars) + 2, 3)
+    add_vertex!(source_tn, v1)
+    add_vertex!(remain_tn, v2)
+    source_tn[v1] = t1
+    remain_tn[v2] = t2
+  end
   return source_tn, remain_tn
 end
 
@@ -27,9 +47,12 @@ Given an input tn and a rooted binary tree of indices, return a partition of tn 
 same binary tree structure as inds_btree.
 Note: in the output partition, we add multiple delta tensors to the network so that
   the output graph is guaranteed to be the same binary tree as inds_btree.
+Note: in the output partition, we add multiple scalar tensors. These tensors are used to
+  make the output partition connected, even if the input `tn` is disconnected.
 Note: in the output partition, tensor vertex names will be changed. For a given input
-  tensor with vertex name `v``, its name in the output partition will be `(v, 1)`, and any
-  delta tensor will have name `(v, 2)`.
+  tensor with vertex name `v``, its name in the output partition will be `(v, 1)`. Any
+  delta tensor will have name `(v, 2)`, and any scalar tensor used to maintain the connectivity
+  of the partition will have name `(v, 3)`.
 Note: for a given binary tree with n indices, the output partition will contain 2n-1 vertices,
   with each leaf vertex corresponding to a sub tn adjacent to one output index. Keeping these
   leaf vertices in the partition makes later `approx_itensornetwork` algorithms more efficient.
@@ -42,6 +65,7 @@ function partition(
   @assert _is_rooted_directed_binary_tree(inds_btree)
   output_tns = Vector{ITensorNetwork}()
   output_deltas_vector = Vector{Vector{ITensor}}()
+  scalars_vector = Vector{Vector{ITensor}}()
   # Mapping each vertex of the binary tree to a tn representing the partition
   # of the subtree containing this vertex and its descendant vertices.
   leaves = leaf_vertices(inds_btree)
@@ -64,18 +88,23 @@ function partition(
     end
     tn = rename_vertices(u -> u[1], subgraph(u -> u[2] == 1, input_tn))
     deltas = Vector{ITensor}(subgraph(u -> u[2] == 2, input_tn))
+    scalars = Vector{ITensor}(subgraph(u -> u[2] == 3, input_tn))
     push!(output_tns, tn)
     push!(output_deltas_vector, deltas)
+    push!(scalars_vector, scalars)
   end
   # In subgraph_vertices, each element is a vector of vertices to be
   # grouped in one partition.
   subgraph_vs = Vector{Vector{Tuple}}()
   delta_num = 0
-  for (tn, deltas) in zip(output_tns, output_deltas_vector)
+  scalar_num = 0
+  for (tn, deltas, scalars) in zip(output_tns, output_deltas_vector, scalars_vector)
     vs = Vector{Tuple}([(v, 1) for v in vertices(tn)])
     vs = vcat(vs, [(i + delta_num, 2) for i in 1:length(deltas)])
+    vs = vcat(vs, [(i + scalar_num, 3) for i in 1:length(scalars)])
     push!(subgraph_vs, vs)
     delta_num += length(deltas)
+    scalar_num += length(scalars)
   end
   out_tn = ITensorNetwork()
   for tn in output_tns
@@ -85,7 +114,9 @@ function partition(
     end
   end
   tn_deltas = ITensorNetwork(vcat(output_deltas_vector...))
-  par = partition(disjoint_union(out_tn, tn_deltas), subgraph_vs)
+  tn_scalars = ITensorNetwork(vcat(scalars_vector...))
+  par = partition(disjoint_union(out_tn, tn_deltas, tn_scalars), subgraph_vs)
+  @assert is_tree(par)
   name_map = Dict()
   for (i, v) in enumerate(pre_order_dfs_vertices(inds_btree, root))
     name_map[i] = v

--- a/test/test_binary_tree_partition.jl
+++ b/test/test_binary_tree_partition.jl
@@ -54,7 +54,17 @@ end
   end
 end
 
-@testset "test binary_tree_partition and approx_itensornetwork" begin
+@testset "test partition with mincut_recursive_bisection alg of disconnected tn" begin
+  inds = [Index(2, "$i") for i in 1:5]
+  tn = ITensorNetwork([randomITensor(i) for i in inds])
+  par = partition(tn, binary_tree_structure(tn); alg="mincut_recursive_bisection")
+  @info par
+  networks = [Vector{ITensor}(par[v]) for v in vertices(par)]
+  network = vcat(networks...)
+  @test isapprox(contract(Vector{ITensor}(tn)), contract(network...))
+end
+
+@testset "test partition with mincut_recursive_bisection alg and approx_itensornetwork" begin
   i = Index(2, "i")
   j = Index(2, "j")
   k = Index(2, "k")

--- a/test/test_binary_tree_partition.jl
+++ b/test/test_binary_tree_partition.jl
@@ -58,7 +58,6 @@ end
   inds = [Index(2, "$i") for i in 1:5]
   tn = ITensorNetwork([randomITensor(i) for i in inds])
   par = partition(tn, binary_tree_structure(tn); alg="mincut_recursive_bisection")
-  @info par
   networks = [Vector{ITensor}(par[v]) for v in vertices(par)]
   network = vcat(networks...)
   @test isapprox(contract(Vector{ITensor}(tn)), contract(network...))


### PR DESCRIPTION
This PR makes binary tree partition work when the input tn is disconnected. Example:
```julia
inds = [Index(2, "$i") for i in 1:5]
tn = ITensorNetwork([randomITensor(i) for i in inds])
par = partition(tn, binary_tree_structure(tn); alg="mincut_recursive_bisection")
```
For this case, we still want `par` to be connected so that it has a binary tree structure. To achieve that, we add multiple scalar tensors with value 1.0 to maintain connectivity, without changing the output value. 