### PR TITLE
Introduce `contraction_sequence_to_digraph` and simplify `contraction_sequence_to_graph`

### DIFF
--- a/src/contraction_tree_to_graph.jl
+++ b/src/contraction_tree_to_graph.jl
@@ -1,7 +1,7 @@
 """
 Take a contraction sequence and return a directed graph.
 """
-function contraction_sequence_to_directed_graph(contract_sequence)
+function contraction_sequence_to_graph(contract_sequence)
   g = NamedDiGraph()
   leaves = collect(Leaves(contract_sequence))
   seq_to_v = Dict()
@@ -25,24 +25,7 @@ function contraction_sequence_to_directed_graph(contract_sequence)
   return g
 end
 
-"""
-Take a contraction_sequence and return a graphical representation of it. The leaves of the graph represent the leaves of the sequence whilst the internal_nodes of the graph
-define a tripartition of the graph and thus are named as an n = 3 element tuples, which each element specifying the keys involved.
-Edges connect parents/children within the contraction sequence.
-"""
-function contraction_sequence_to_graph(contract_sequence)
-  direct_g = contraction_sequence_to_directed_graph(contract_sequence)
-  g = NamedGraph(vertices(direct_g))
-  for e in edges(direct_g)
-    add_edge!(g, e)
-  end
-  root = _root(direct_g)
-  c1, c2 = child_vertices(direct_g, root)
-  rem_vertex!(g, root)
-  add_edge!(g, c1 => c2)
-  return g
-end
-
+#=
 """Get the vertex bi-partition that a given edge represents"""
 function contraction_tree_leaf_bipartition(g::AbstractGraph, e)
   if (!is_leaf_edge(g, e))
@@ -75,3 +58,4 @@ function contraction_tree_leaf_bipartition(g::AbstractGraph, e)
 
   return left_bipartition, right_bipartition
 end
+=#

--- a/src/contraction_tree_to_graph.jl
+++ b/src/contraction_tree_to_graph.jl
@@ -1,7 +1,7 @@
 """
 Take a contraction sequence and return a directed graph.
 """
-function contraction_sequence_to_graph(contract_sequence)
+function contraction_sequence_to_digraph(contract_sequence)
   g = NamedDiGraph()
   leaves = collect(Leaves(contract_sequence))
   seq_to_v = Dict()
@@ -25,7 +25,24 @@ function contraction_sequence_to_graph(contract_sequence)
   return g
 end
 
-#=
+"""
+Take a contraction_sequence and return a graphical representation of it. The leaves of the graph represent the leaves of the sequence whilst the internal_nodes of the graph
+define a tripartition of the graph and thus are named as an n = 3 element tuples, which each element specifying the keys involved.
+Edges connect parents/children within the contraction sequence.
+"""
+function contraction_sequence_to_graph(contract_sequence)
+  direct_g = contraction_sequence_to_directed_graph(contract_sequence)
+  g = NamedGraph(vertices(direct_g))
+  for e in edges(direct_g)
+    add_edge!(g, e)
+  end
+  root = _root(direct_g)
+  c1, c2 = child_vertices(direct_g, root)
+  rem_vertex!(g, root)
+  add_edge!(g, c1 => c2)
+  return g
+end
+
 """Get the vertex bi-partition that a given edge represents"""
 function contraction_tree_leaf_bipartition(g::AbstractGraph, e)
   if (!is_leaf_edge(g, e))
@@ -58,4 +75,3 @@ function contraction_tree_leaf_bipartition(g::AbstractGraph, e)
 
   return left_bipartition, right_bipartition
 end
-=#

--- a/src/contraction_tree_to_graph.jl
+++ b/src/contraction_tree_to_graph.jl
@@ -31,7 +31,7 @@ define a tripartition of the graph and thus are named as an n = 3 element tuples
 Edges connect parents/children within the contraction sequence.
 """
 function contraction_sequence_to_graph(contract_sequence)
-  direct_g = contraction_sequence_to_directed_graph(contract_sequence)
+  direct_g = contraction_sequence_to_digraph(contract_sequence)
   g = NamedGraph(vertices(direct_g))
   for e in edges(direct_g)
     add_edge!(g, e)

--- a/test/test_contraction_sequence_to_graph.jl
+++ b/test/test_contraction_sequence_to_graph.jl
@@ -1,6 +1,12 @@
 using ITensorNetworks
 using ITensorNetworks:
-  contraction_sequence_to_graph, internal_edges, distance_to_leaf, leaf_vertices, _root
+  contraction_sequence_to_digraph,
+  contraction_sequence_to_graph,
+  internal_edges,
+  contraction_tree_leaf_bipartition,
+  distance_to_leaf,
+  leaf_vertices,
+  _root
 using Test
 using ITensors
 using NamedGraphs
@@ -16,17 +22,21 @@ using NamedGraphs
 
   seq = contraction_sequence(ψψ)
 
-  g_seq = contraction_sequence_to_graph(seq)
-  g_seq_leaves = leaf_vertices(g_seq)
+  g_directed_seq = contraction_sequence_to_digraph(seq)
+  g_seq_leaves = leaf_vertices(g_directed_seq)
   @test length(g_seq_leaves) == n * n
-  @test 2 * length(g_seq_leaves) - 1 == length(vertices(g_seq))
-  @test _root(g_seq)[3] == []
+  @test 2 * length(g_seq_leaves) - 1 == length(vertices(g_directed_seq))
+  @test _root(g_directed_seq)[3] == []
 
-  # for eb in internal_edges(g_seq)
-  #   vs = contraction_tree_leaf_bipartition(g_seq, eb)
-  #   @test length(vs) == 2
-  #   @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(ψψ))
-  # end
+  g_seq = contraction_sequence_to_graph(seq)
+  @test length(g_seq_leaves) == n * n
+  @test 2 * length(g_seq_leaves) - 2 == length(vertices(g_seq))
+
+  for eb in internal_edges(g_seq)
+    vs = contraction_tree_leaf_bipartition(g_seq, eb)
+    @test length(vs) == 2
+    @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(ψψ))
+  end
   #Check all internal vertices define a correct tripartition and all leaf vertices define a bipartition (tensor on that leafs vs tensor on rest of tree)
   for v in vertices(g_seq)
     if (!is_leaf(g_seq, v))

--- a/test/test_contraction_sequence_to_graph.jl
+++ b/test/test_contraction_sequence_to_graph.jl
@@ -1,10 +1,12 @@
 using ITensorNetworks
 using ITensorNetworks:
+  contraction_sequence_to_directed_graph,
   contraction_sequence_to_graph,
   internal_edges,
   contraction_tree_leaf_bipartition,
   distance_to_leaf,
-  leaf_vertices
+  leaf_vertices,
+  _root
 using Test
 using ITensors
 using NamedGraphs
@@ -20,12 +22,15 @@ using NamedGraphs
 
   seq = contraction_sequence(ψψ)
 
-  g_seq = contraction_sequence_to_graph(seq)
-
-  #Get all leaf nodes (should match number of tensors in original network)
-  g_seq_leaves = leaf_vertices(g_seq)
-
+  g_directed_seq = contraction_sequence_to_directed_graph(seq)
+  g_seq_leaves = leaf_vertices(g_directed_seq)
   @test length(g_seq_leaves) == n * n
+  @test 2 * length(g_seq_leaves) - 1 == length(vertices(g_directed_seq))
+  @test _root(g_directed_seq)[3] == []
+
+  g_seq = contraction_sequence_to_graph(seq)
+  @test length(g_seq_leaves) == n * n
+  @test 2 * length(g_seq_leaves) - 2 == length(vertices(g_seq))
 
   for eb in internal_edges(g_seq)
     vs = contraction_tree_leaf_bipartition(g_seq, eb)

--- a/test/test_contraction_sequence_to_graph.jl
+++ b/test/test_contraction_sequence_to_graph.jl
@@ -1,12 +1,6 @@
 using ITensorNetworks
 using ITensorNetworks:
-  contraction_sequence_to_directed_graph,
-  contraction_sequence_to_graph,
-  internal_edges,
-  contraction_tree_leaf_bipartition,
-  distance_to_leaf,
-  leaf_vertices,
-  _root
+  contraction_sequence_to_graph, internal_edges, distance_to_leaf, leaf_vertices, _root
 using Test
 using ITensors
 using NamedGraphs
@@ -22,21 +16,17 @@ using NamedGraphs
 
   seq = contraction_sequence(ψψ)
 
-  g_directed_seq = contraction_sequence_to_directed_graph(seq)
-  g_seq_leaves = leaf_vertices(g_directed_seq)
-  @test length(g_seq_leaves) == n * n
-  @test 2 * length(g_seq_leaves) - 1 == length(vertices(g_directed_seq))
-  @test _root(g_directed_seq)[3] == []
-
   g_seq = contraction_sequence_to_graph(seq)
+  g_seq_leaves = leaf_vertices(g_seq)
   @test length(g_seq_leaves) == n * n
-  @test 2 * length(g_seq_leaves) - 2 == length(vertices(g_seq))
+  @test 2 * length(g_seq_leaves) - 1 == length(vertices(g_seq))
+  @test _root(g_seq)[3] == []
 
-  for eb in internal_edges(g_seq)
-    vs = contraction_tree_leaf_bipartition(g_seq, eb)
-    @test length(vs) == 2
-    @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(ψψ))
-  end
+  # for eb in internal_edges(g_seq)
+  #   vs = contraction_tree_leaf_bipartition(g_seq, eb)
+  #   @test length(vs) == 2
+  #   @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(ψψ))
+  # end
   #Check all internal vertices define a correct tripartition and all leaf vertices define a bipartition (tensor on that leafs vs tensor on rest of tree)
   for v in vertices(g_seq)
     if (!is_leaf(g_seq, v))


### PR DESCRIPTION
Given a contraction sequence, the output of  `contraction_sequence_to_graph` gives the partition information of the contraction sequence. However, multiple important information such as the contraction order, as well as the root of the contraction sequence, is lost. The output of `contraction_sequence_to_digraph` is a directed graph that keeps such informations.

Example: when the input sequence is [[1,2], [3,4]], the output of the `contraction_sequence_to_digraph` will be a graph with the structure of 
```
    [1,2,3,4]
     /    \
[1,2]  [3,4]
 /  \    /  \
1    2   3   4
```
while the output of `contraction_sequence_to_graph` will be an undirected graph with the structure of 
```
[1,2]----[3,4]
 /  \    /  \
1    2   3   4
```