### PR TITLE
Fix channel compression in `OpSum` to `TTN` converter

### DIFF
--- a/src/treetensornetworks/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn.jl
@@ -398,7 +398,6 @@ function TTN(eltype::Type{<:Number}, os, sites::IndsNetwork; kwargs...)
   return NDTensors.convert_scalartype(eltype, TTN(os, sites; kwargs...))
 end
 
-
 # 
 # Tree adaptation of functionalities in ITensors.jl/src/physics/autompo/matelem.jl
 # 
@@ -424,7 +423,6 @@ function Base.isless(a1::ArrElem{T,N}, a2::ArrElem{T,N})::Bool where {T,N}
   end
   return a1.val < a2.val
 end
-
 
 # 
 # Sparse finite state machine construction

--- a/src/treetensornetworks/opsum_to_ttn.jl
+++ b/src/treetensornetworks/opsum_to_ttn.jl
@@ -1,19 +1,16 @@
 # convert ITensors.OpSum to TreeTensorNetwork
 
-# TODO: fix symbolic SVD compression for certain combinations of long-range interactions!
-
 # 
 # Utility methods
 # 
 
-# linear ordering of vertices in tree graph relative to chosen root
+# linear ordering of vertices in tree graph relative to chosen root, chosen outward from root
 function find_index_in_tree(site, g::AbstractGraph, root_vertex)
-  ordering = post_order_dfs_vertices(g, root_vertex)
+  ordering = reverse(post_order_dfs_vertices(g, root_vertex))
   return findfirst(x -> x == site, ordering)
 end
-
 function find_index_in_tree(o::Op, g::AbstractGraph, root_vertex)
-  return find_index_in_tree(ITensors.site(o), g::AbstractGraph, root_vertex)
+  return find_index_in_tree(ITensors.site(o), g, root_vertex)
 end
 
 # determine 'support' of product operator on tree graph
@@ -32,188 +29,10 @@ function crosses_vertex(t::Scaled{C,Prod{Op}}, g::AbstractGraph, v) where {C}
   return v ∈ span(t, g)
 end
 
-# allow sparse arrays with ITensors.Sum entries
-function Base.zero(::Type{S}) where {S<:Sum}
-  return S()
-end
-Base.zero(t::Sum) = zero(typeof(t))
-
 # 
 # Tree adaptations of functionalities in ITensors.jl/src/physics/autompo/opsum_to_mpo.jl
 # 
 
-"""
-    finite_state_machine(os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V) where {C,V}
-
-Finite state machine generator for ITensors.OpSum Hamiltonian defined on a tree graph. The
-site Index graph must be a tree graph, and the chosen root  must be a leaf vertex of this
-tree. Returns a DataGraph of SparseArrayKit.SparseArrays
-"""
-function finite_state_machine(
-  os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V
-) where {C,V}
-  os = deepcopy(os)
-  os = sorteachterm(os, sites, root_vertex)
-  os = ITensors.sortmergeterms(os)
-
-  ValType = ITensors.determineValType(ITensors.terms(os))
-
-  # sparse symbolic representation of the TTN Hamiltonian as a DataGraph of SparseArrays
-  sparseTTN = DataGraph{V,SparseArray{Sum{Scaled{ValType,Prod{Op}}}}}(
-    underlying_graph(sites)
-  )
-
-  # some things to keep track of
-  vs = post_order_dfs_vertices(sites, root_vertex)                                          # store vertices in fixed ordering relative to root
-  es = post_order_dfs_edges(sites, root_vertex)                                             # store edges in fixed ordering relative to root
-  ranks = Dict(v => degree(sites, v) for v in vs)                                           # rank of every TTN tensor in network
-  linkmaps = Dict(e => Dict{Prod{Op},Int}() for e in es)                                    # map from term in Hamiltonian to edge channel index for every edge
-  site_coef_done = Prod{Op}[]                                                               # list of Hamiltonian terms for which the coefficient has been added to a site factor
-  edge_orders = DataGraph{V,Vector{edgetype(sites)}}(underlying_graph(sites))               # relate indices of sparse TTN tensor to incident graph edges for each site
-
-  for v in vs
-    # collect all nontrivial entries of the TTN tensor at vertex v
-    entries = Tuple{MVector{ranks[v],Int},Scaled{ValType,Prod{Op}}}[]                       # MVector might be overkill...
-
-    # for every vertex, find all edges that contain this vertex
-    edges = filter(e -> dst(e) == v || src(e) == v, es)
-    # use the corresponding ordering as index order for tensor elements at this site
-    edge_orders[v] = edges
-    dims_in = findall(e -> dst(e) == v, edges)
-    edges_in = edges[dims_in]
-    dim_out = findfirst(e -> src(e) == v, edges)
-    edge_out = (isnothing(dim_out) ? [] : edges[dim_out])
-
-    # sanity check, leaves only have single incoming or outgoing edge
-    @assert !isempty(dims_in) || !isnothing(dim_out)
-    (isempty(dims_in) || isnothing(dim_out)) && @assert is_leaf(sites, v)
-
-    for term in os
-      # loop over OpSum and pick out terms that act on current vertex
-      crosses_vertex(term, sites, v) || continue
-
-      # for every incoming edge, filter out factors that come in from the direction of
-      # that edge
-      incoming = Dict(
-        e => filter(t -> e ∈ edge_path(sites, ITensors.site(t), v), ITensors.terms(term))
-        for e in edges_in
-      )
-      # filter out factor that acts on current vertex
-      onsite = filter(t -> (ITensors.site(t) == v), ITensors.terms(term))
-      # filter out factors that go out along the outgoing edge
-      outgoing = filter(
-        t -> edge_out ∈ edge_path(sites, v, ITensors.site(t)), ITensors.terms(term)
-      )
-
-      # translate into sparse tensor entry
-      T_inds = fill(-1, ranks[v])
-      for din in dims_in
-        if !isempty(incoming[edges[din]])
-          T_inds[din] = ITensors.posInLink!(linkmaps[edges[din]], ITensors.argument(term)) # get incoming channel
-        end
-      end
-      if !isnothing(dim_out) && !isempty(outgoing)
-        T_inds[dim_out] = ITensors.posInLink!(linkmaps[edge_out], ITensors.argument(term)) # add outgoing channel
-      end
-      # if term starts at this site, add its coefficient as a site factor
-      site_coef = one(ValType)
-      if (isempty(dims_in) || all(T_inds[dims_in] .== -1)) &&
-        ITensors.argument(term) ∉ site_coef_done
-        site_coef = ITensors.coefficient(term)
-        push!(site_coef_done, ITensors.argument(term))
-      end
-      # add onsite identity for interactions passing through vertex
-      if isempty(onsite)
-        if !ITensors.using_auto_fermion() && isfermionic(outgoing, sites)                   # TODO: check if fermions are actually supported here!
-          push!(onsite, Op("F", v))
-        else
-          push!(onsite, Op("Id", v))
-        end
-      end
-      # save indices and value of sparse tensor entry
-      el = (MVector{ranks[v]}(T_inds), site_coef * Prod(onsite))
-      push!(entries, el)
-    end
-
-    # handle start and end of operator terms and convert to sparse array
-    linkdims = Tuple([
-      (isempty(linkmaps[e]) ? 0 : maximum(values(linkmaps[e]))) + 2 for e in edges
-    ])
-    T = SparseArray{Sum{Scaled{ValType,Prod{Op}}},ranks[v]}(undef, linkdims)
-    for (T_inds, t) in entries
-      if !isempty(dims_in)
-        start_dims = filter(d -> T_inds[d] == -1, dims_in)
-        normal_dims = filter(d -> T_inds[d] != -1, dims_in)
-        T_inds[start_dims] .= 1 # always start in first channel
-        T_inds[normal_dims] .+= 1 # shift regular channels
-      end
-      if !isnothing(dim_out)
-        if T_inds[dim_out] == -1
-          T_inds[dim_out] = linkdims[dim_out] # always end in last channel
-        else
-          T_inds[dim_out] += 1 # shift regular channel
-        end
-      end
-      T[T_inds...] += t
-    end
-    # add starting and ending identity operators
-    if !isnothing(dim_out)
-      T[ones(Int, ranks[v])...] += one(ValType) * Prod([Op("Id", v)]) # starting identity is easy
-    end
-    # ending identities not so much
-    idT_end_inds = ones(Int, ranks[v])
-    if !isnothing(dim_out)
-      idT_end_inds[dim_out] = linkdims[dim_out]
-    end
-    for din in dims_in
-      idT_end_inds[din] = linkdims[din]
-      T[idT_end_inds...] += one(ValType) * Prod([Op("Id", v)])
-      idT_end_inds[din] = 1 # reset
-    end
-    sparseTTN[v] = T
-  end
-  return sparseTTN, edge_orders
-end
-
-"""
-    fsmTTN(os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V, kwargs...) where {C,V}
-
-Construct a dense TreeTensorNetwork from sparse finite state machine
-represenatation, without compression.
-"""
-function fsmTTN(
-  os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V
-)::TTN where {C,V}
-  ValType = ITensors.determineValType(ITensors.terms(os))
-  # start from finite state machine
-  fsm, edge_orders = finite_state_machine(os, sites, root_vertex)
-  # some trickery to get link dimension for every edge
-  link_space = Dict{edgetype(sites),Index}()
-  function get_linkind!(link_space, e)
-    if !haskey(link_space, e)
-      d = findfirst(x -> (x == e || x == reverse(e)), edge_orders[src(e)])
-      link_space[e] = Index(size(fsm[src(e)], d), edge_tag(e))
-    end
-    return link_space[e]
-  end
-  # compress finite state machine into dense form
-  H = TTN(sites)
-  for v in vertices(sites)
-    linkinds = [get_linkind!(link_space, e) for e in edge_orders[v]]
-    linkdims = dim.(linkinds)
-    H[v] = ITensor()
-    for (T_ind, t) in nonzero_pairs(fsm[v])
-      any(map(x -> abs(coefficient(x)) > eps(), t)) || continue
-      T = zeros(ValType, linkdims...)
-      T[T_ind] += one(ValType)
-      T = itensor(T, linkinds)
-      H[v] += T * computeSiteSum(sites, t)
-    end
-  end
-  return H
-end
-
-# this is broken for certain combinations of longer-range interactions, no idea why...
 """
     svdTTN(os::OpSum{C}, sites::IndsNetwork{V<:Index}, root_vertex::V, kwargs...) where {C,V}
 
@@ -225,130 +44,118 @@ function svdTTN(
 )::TTN where {C,VT}
   mindim::Int = get(kwargs, :mindim, 1)
   maxdim::Int = get(kwargs, :maxdim, 10000)
-  cutoff::Float64 = get(kwargs, :cutoff, 1E-15)
+  cutoff::Float64 = get(kwargs, :cutoff, 1e-15)
 
   ValType = ITensors.determineValType(ITensors.terms(os))
 
+  # traverse tree outwards from root vertex
+  vs = reverse(post_order_dfs_vertices(sites, root_vertex))                                 # store vertices in fixed ordering relative to root
+  es = reverse(reverse.(post_order_dfs_edges(sites, root_vertex)))                          # store edges in fixed ordering relative to root
   # some things to keep track of
-  vs = post_order_dfs_vertices(sites, root_vertex)                                          # store vertices in fixed ordering relative to root
-  es = post_order_dfs_edges(sites, root_vertex)                                             # store edges in fixed ordering relative to root
   ranks = Dict(v => degree(sites, v) for v in vs)                                           # rank of every TTN tensor in network
   Vs = Dict(e => Matrix{ValType}(undef, 1, 1) for e in es)                                  # link isometries for SVD compression of TTN
-  leftmaps = Dict(e => Dict{Vector{Op},Int}() for e in es)                                  # map from term in Hamiltonian to edge left channel index for every edge
-  rightmaps = Dict(e => Dict{Vector{Op},Int}() for e in es)                                 # map from term in Hamiltonian to edge right channel index for every edge
-  leftbond_coefs = Dict(e => ITensors.MatElem{ValType}[] for e in es)                       # bond coefficients for left edge channels
+  inmaps = Dict(e => Dict{Vector{Op},Int}() for e in es)                                    # map from term in Hamiltonian to incoming channel index for every edge
+  outmaps = Dict(e => Dict{Vector{Op},Int}() for e in es)                                   # map from term in Hamiltonian to outgoing channel index for every edge
+  inbond_coefs = Dict(e => ITensors.MatElem{ValType}[] for e in es)                         # bond coefficients for incoming edge channels
   site_coef_done = Prod{Op}[]                                                               # list of terms for which the coefficient has been added to a site factor
-  bond_coef_done = Dict(v => Prod{Op}[] for v in vs)                                        # list of terms for which the coefficient has been added to a bond matrix for each vertex
 
   # temporary symbolic representation of TTN Hamiltonian
-  tempTTN = Dict(v => Tuple{MVector{ranks[v],Int},Scaled{C,Prod{Op}}}[] for v in vs)
+  tempTTN = Dict(v => ArrElem{Scaled{C,Prod{Op}},ranks[v]}[] for v in vs)
 
   # build compressed finite state machine representation
   for v in vs
     # for every vertex, find all edges that contain this vertex
     edges = filter(e -> dst(e) == v || src(e) == v, es)
     # use the corresponding ordering as index order for tensor elements at this site
-    dims_in = findall(e -> dst(e) == v, edges)
-    edges_in = edges[dims_in]
-    dim_out = findfirst(e -> src(e) == v, edges)
-    edge_out = (isnothing(dim_out) ? [] : edges[dim_out])
+    dim_in = findfirst(e -> dst(e) == v, edges)
+    edge_in = (isnothing(dim_in) ? [] : edges[dim_in])
+    dims_out = findall(e -> src(e) == v, edges)
+    edges_out = edges[dims_out]
 
     # sanity check, leaves only have single incoming or outgoing edge
-    @assert !isempty(dims_in) || !isnothing(dim_out)
-    (isempty(dims_in) || isnothing(dim_out)) && @assert is_leaf(sites, v)
+    @assert !isempty(dims_out) || !isnothing(dim_in)
+    (isempty(dims_out) || isnothing(dim_in)) && @assert is_leaf(sites, v)
 
     for term in os
       # loop over OpSum and pick out terms that act on current vertex
       crosses_vertex(term, sites, v) || continue
 
-      # for every incoming edge, filter out factors that come in from the direction of
-      # that edge
-      incoming = Dict(
-        e => filter(t -> e ∈ edge_path(sites, ITensors.site(t), v), ITensors.terms(term))
-        for e in edges_in
+      # filter out factors that come in from the direction of the incoming edge
+      incoming = filter(
+        t -> edge_in ∈ edge_path(sites, ITensors.site(t), v), ITensors.terms(term)
+      )
+      # also store all non-incoming factors in standard order, used for channel merging
+      not_incoming = filter(
+        t -> edge_in ∉ edge_path(sites, ITensors.site(t), v), ITensors.terms(term)
       )
       # filter out factor that acts on current vertex
       onsite = filter(t -> (ITensors.site(t) == v), ITensors.terms(term))
-      # filter out factors that go out along the outgoing edge
-      outgoing = filter(
-        t -> edge_out ∈ edge_path(sites, v, ITensors.site(t)), ITensors.terms(term)
+      # for every outgoing edge, filter out factors that go out along that edge
+      outgoing = Dict(
+        e => filter(t -> e ∈ edge_path(sites, v, ITensors.site(t)), ITensors.terms(term))
+        for e in edges_out
       )
 
       # translate into tensor entry
-      T_inds = fill(-1, ranks[v])
-      # channel merging still not working properly somehow!
-      for din in dims_in
-        bond_row = -1
-        bond_col = -1
-        # treat factors coming in along current edge as 'left'
-        left = incoming[edges[din]]
-        other_dims_in = filter(dd -> dd != din, dims_in)
-        other_incoming = [incoming[edges[dd]] for dd in other_dims_in]
-        # treat all other factors as 'right'
-        right = vcat(other_incoming..., outgoing)
-        if !isempty(left)
-          bond_row = ITensors.posInLink!(leftmaps[edges[din]], left)
-          bond_col = ITensors.posInLink!(rightmaps[edges[din]], vcat(onsite, right)) # get incoming channel
-          bond_coef = one(ValType)
-          if ITensors.argument(term) ∉ bond_coef_done[v]
-            bond_coef *= convert(ValType, ITensors.coefficient(term))
-            push!(bond_coef_done[v], ITensors.argument(term))
-          end
-          push!(leftbond_coefs[edges[din]], ITensors.MatElem(bond_row, bond_col, bond_coef))
-        end
-        T_inds[din] = bond_col
+      T_inds = MVector{ranks[v]}(fill(-1, ranks[v]))
+      bond_row = -1
+      bond_col = -1
+      if !isempty(incoming)
+        bond_row = ITensors.posInLink!(inmaps[edge_in], incoming)
+        bond_col = ITensors.posInLink!(outmaps[edge_in], not_incoming) # get incoming channel
+        bond_coef = convert(ValType, ITensors.coefficient(term))
+        push!(inbond_coefs[edge_in], ITensors.MatElem(bond_row, bond_col, bond_coef))
+        T_inds[dim_in] = bond_col
       end
-      if !isnothing(dim_out) && !isempty(outgoing)
-        T_inds[dim_out] = ITensors.posInLink!(rightmaps[edge_out], outgoing) # add outgoing channel
+      for dout in dims_out
+        T_inds[dout] = ITensors.posInLink!(outmaps[edges[dout]], outgoing[edges[dout]]) # add outgoing channel
       end
       # if term starts at this site, add its coefficient as a site factor
       site_coef = one(C)
-      if (isempty(dims_in) || all(T_inds[dims_in] .== -1)) &&
+      if (isnothing(dim_in) || T_inds[dim_in] == -1) &&
         ITensors.argument(term) ∉ site_coef_done
         site_coef = ITensors.coefficient(term)
         push!(site_coef_done, ITensors.argument(term))
       end
       # add onsite identity for interactions passing through vertex
       if isempty(onsite)
-        if !ITensors.using_auto_fermion() && isfermionic(outgoing, sites)                   # TODO: check if fermions are actually supported here!
-          push!(onsite, Op("F", v))
+        if !ITensors.using_auto_fermion() && isfermionic(incoming, sites)
+          error("No verified fermion support for automatic TTN constructor!")
         else
           push!(onsite, Op("Id", v))
         end
       end
       # save indices and value of symbolic tensor entry
-      el = (MVector{ranks[v]}(T_inds), site_coef * Prod(onsite))
+      el = ArrElem(T_inds, site_coef * Prod(onsite))
       push!(tempTTN[v], el)
     end
     ITensors.remove_dups!(tempTTN[v])
-    # handle symbolic truncation (still something wrong with this)
-    for din in dims_in
-      if !isempty(leftbond_coefs[edges[din]])
-        M = ITensors.toMatrix(leftbond_coefs[edges[din]])
-        U, S, V = svd(M)
-        P = S .^ 2
-        truncate!(P; maxdim=maxdim, cutoff=cutoff, mindim=mindim)
-        tdim = length(P)
-        nc = size(M, 2)
-        Vs[edges[din]] = Matrix{ValType}(V[1:nc, 1:tdim])
-      end
+    # manual truncation: isometry on incoming edge
+    if !isnothing(dim_in) && !isempty(inbond_coefs[edges[dim_in]])
+      M = ITensors.toMatrix(inbond_coefs[edges[dim_in]])
+      U, S, V = svd(M)
+      P = S .^ 2
+      truncate!(P; maxdim=maxdim, cutoff=cutoff, mindim=mindim)
+      tdim = length(P)
+      nc = size(M, 2)
+      Vs[edges[dim_in]] = Matrix{ValType}(V[1:nc, 1:tdim])
     end
   end
 
   # compress this tempTTN representation into dense form
 
   link_space = dictionary([
-    e => Index((isempty(rightmaps[e]) ? 0 : size(Vs[e], 2)) + 2, edge_tag(e)) for e in es
+    e => Index((isempty(outmaps[e]) ? 0 : size(Vs[e], 2)) + 2, edge_tag(e)) for e in es
   ])
 
   H = TTN(sites)
 
-  for v in vs # can I merge this with previous loop? no, need all need the Vs...
+  for v in vs
 
     # redo the whole thing like before
     edges = filter(e -> dst(e) == v || src(e) == v, es)
-    dims_in = findall(e -> dst(e) == v, edges)
-    dim_out = findfirst(e -> src(e) == v, edges)
+    dim_in = findfirst(e -> dst(e) == v, edges)
+    dims_out = findall(e -> src(e) == v, edges)
 
     # slice isometries at this vertex
     Vv = [Vs[e] for e in edges]
@@ -358,27 +165,29 @@ function svdTTN(
 
     H[v] = ITensor()
 
-    for (T_inds, t) in tempTTN[v]
+    for el in tempTTN[v]
+      T_inds = el.idxs
+      t = el.val
       (abs(coefficient(t)) > eps()) || continue
       T = zeros(ValType, linkdims...)
       ct = convert(ValType, coefficient(t))
       terminal_dims = findall(d -> T_inds[d] == -1, 1:ranks[v])   # directions in which term starts or ends
       normal_dims = findall(d -> T_inds[d] ≠ -1, 1:ranks[v])      # normal dimensions, do truncation thingies
       T_inds[terminal_dims] .= 1                                  # start in channel 1
-      if !isnothing(dim_out) && dim_out ∈ terminal_dims
-        T_inds[dim_out] = linkdims[dim_out]                       # end in channel linkdims[d] for each dimension d
+      for dout in filter(d -> d ∈ terminal_dims, dims_out)
+        T_inds[dout] = linkdims[dout]                             # end in channel linkdims[d] for each dimension d
       end
       if isempty(normal_dims)
         T[T_inds...] += ct                                        # on-site term
       else
-        # abracadabra?
+        # handle channel compression isometries
         dim_ranges = Tuple(size(Vv[d], 2) for d in normal_dims)
         for c in CartesianIndices(dim_ranges)
           z = ct
           temp_inds = copy(T_inds)
           for (i, d) in enumerate(normal_dims)
             V_factor = Vv[d][T_inds[d], c[i]]
-            z *= (d ∈ dims_in ? conj(V_factor) : V_factor)
+            z *= (d == dim_in ? conj(V_factor) : V_factor) # conjugate incoming isemetry factor
             temp_inds[d] = 1 + c[i]
           end
           T[temp_inds...] += z
@@ -390,21 +199,23 @@ function svdTTN(
 
     # add starting and ending identity operators
     idT = zeros(ValType, linkdims...)
-    if !isnothing(dim_out)
-      idT[ones(Int, ranks[v])...] = 1.0 # starting identity is easy
+    if isnothing(dim_in)
+      idT[ones(Int, ranks[v])...] = 1.0 # only one real starting identity
     end
-    # ending identities not so much
-    idT_end_inds = ones(Int, ranks[v])
-    if !isnothing(dim_out)
-      idT_end_inds[dim_out] = linkdims[dim_out]
-    end
-    for din in dims_in
-      idT_end_inds[din] = linkdims[din]
-      idT[idT_end_inds...] = 1
-      idT_end_inds[din] = 1 # reset
+    # ending identities are a little more involved
+    if !isnothing(dim_in)
+      idT[linkdims...] = 1.0 # place identity if all channels end
+      # place identity from start of incoming channel to start of each single outgoing channel, and end all other channels
+      idT_end_inds = [linkdims...]
+      idT_end_inds[dim_in] = 1.0
+      for dout in dims_out
+        idT_end_inds[dout] = 1.0
+        idT[idT_end_inds...] = 1.0
+        idT_end_inds[dout] = linkdims[dout] # reset
+      end
     end
     T = itensor(idT, linkinds)
-    H[v] += T * computeSiteProd(sites, Prod([Op("Id", v)]))
+    H[v] += T * ITensorNetworks.computeSiteProd(sites, Prod([Op("Id", v)]))
   end
 
   return H
@@ -426,24 +237,6 @@ function isfermionic(t::Vector{Op}, sites::IndsNetwork{V,<:Index}) where {V}
     end
   end
   return (p == -1)
-end
-
-function computeSiteSum(
-  sites::IndsNetwork{V,<:Index}, ops::Sum{Scaled{C,Prod{Op}}}
-)::ITensor where {V,C}
-  ValType = ITensors.determineValType(ITensors.terms(ops))
-  v = ITensors.site(ITensors.argument(ops[1])[1])
-  T =
-    convert(ValType, coefficient(ops[1])) *
-    computeSiteProd(sites, ITensors.argument(ops[1]))
-  for j in 2:length(ops)
-    (ITensors.site(ITensors.argument(ops[j])[1]) != v) &&
-      error("Mismatch of vertex labels in computeSiteSum")
-    T +=
-      convert(ValType, coefficient(ops[j])) *
-      computeSiteProd(sites, ITensors.argument(ops[j]))
-  end
-  return T
 end
 
 # only(site(ops[1])) in ITensors breaks for Tuple site labels, had to drop the only
@@ -537,8 +330,6 @@ function TTN(
   sites::IndsNetwork{V,<:Index};
   root_vertex::V=default_root_vertex(sites),
   splitblocks=false,
-  method::Symbol=:fsm, # default to construction from finite state machine until svdTTN is fixed
-  trunc=false,
   kwargs...,
 )::TTN where {V}
   length(ITensors.terms(os)) == 0 && error("OpSum has no terms")
@@ -565,21 +356,7 @@ function TTN(
     tn = TTN(Dictionary(vertices(sites), [mpo[v] for v in 1:nv(sites)]))
     return tn
   end
-  if method == :svd
-    @warn "Symbolic SVD compression not working for long-range interactions." # add warning until this is fixed
-    T = svdTTN(os, sites, root_vertex; kwargs...)
-  elseif method == :fsm
-    T = fsmTTN(os, sites, root_vertex)
-  end
-  # add option for numerical truncation, but throw warning as this can fail sometimes
-  if trunc
-    @warn "Naive numerical truncation of TTN Hamiltonian may fail for larger systems."
-    # see https://github.com/ITensor/ITensors.jl/issues/526
-    lognormT = lognorm(T)
-    T /= exp(lognormT / nv(T)) # TODO: fix broadcasting for in-place assignment
-    truncate!(T; root_vertex, cutoff=1e-15)
-    T *= exp(lognormT / nv(T))
-  end
+  T = svdTTN(os, sites, root_vertex; kwargs...)
   if splitblocks
     error("splitblocks not yet implemented for AbstractTreeTensorNetwork.")
     T = ITensors.splitblocks(linkinds, T) # TODO: make this work
@@ -619,4 +396,242 @@ end
 # Catch-all for leaf eltype specification
 function TTN(eltype::Type{<:Number}, os, sites::IndsNetwork; kwargs...)
   return NDTensors.convert_scalartype(eltype, TTN(os, sites; kwargs...))
+end
+
+
+# 
+# Tree adaptation of functionalities in ITensors.jl/src/physics/autompo/matelem.jl
+# 
+
+#################################
+# ArrElem (simple sparse array) #
+#################################
+
+struct ArrElem{T,N}
+  idxs::MVector{N,Int}
+  val::T
+end
+
+function Base.:(==)(a1::ArrElem{T,N}, a2::ArrElem{T,N})::Bool where {T,N}
+  return (a1.idxs == a2.idxs && a1.val == a2.val)
+end
+
+function Base.isless(a1::ArrElem{T,N}, a2::ArrElem{T,N})::Bool where {T,N}
+  for n in 1:N
+    if a1.idxs[n] != a2.idxs[n]
+      return a1.idxs[n] < a2.idxs[n]
+    end
+  end
+  return a1.val < a2.val
+end
+
+
+# 
+# Sparse finite state machine construction
+# 
+
+# allow sparse arrays with ITensors.Sum entries
+function Base.zero(::Type{S}) where {S<:Sum}
+  return S()
+end
+Base.zero(t::Sum) = zero(typeof(t))
+
+"""
+    finite_state_machine(os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V) where {C,V}
+
+Finite state machine generator for ITensors.OpSum Hamiltonian defined on a tree graph. The
+site Index graph must be a tree graph, and the chosen root  must be a leaf vertex of this
+tree. Returns a DataGraph of SparseArrayKit.SparseArrays.
+"""
+function finite_state_machine(
+  os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V
+) where {C,V}
+  os = deepcopy(os)
+  os = sorteachterm(os, sites, root_vertex)
+  os = ITensors.sortmergeterms(os)
+
+  ValType = ITensors.determineValType(ITensors.terms(os))
+
+  # sparse symbolic representation of the TTN Hamiltonian as a DataGraph of SparseArrays
+  sparseTTN = DataGraph{V,SparseArray{Sum{Scaled{ValType,Prod{Op}}}}}(
+    underlying_graph(sites)
+  )
+
+  # traverse tree outwards from root vertex
+  vs = reverse(post_order_dfs_vertices(sites, root_vertex))                                 # store vertices in fixed ordering relative to root
+  es = reverse(reverse.(post_order_dfs_edges(sites, root_vertex)))                          # store edges in fixed ordering relative to root
+  # some things to keep track of
+  ranks = Dict(v => degree(sites, v) for v in vs)                                           # rank of every TTN tensor in network
+  linkmaps = Dict(e => Dict{Prod{Op},Int}() for e in es)                                    # map from term in Hamiltonian to edge channel index for every edge
+  site_coef_done = Prod{Op}[]                                                               # list of Hamiltonian terms for which the coefficient has been added to a site factor
+  edge_orders = DataGraph{V,Vector{edgetype(sites)}}(underlying_graph(sites))               # relate indices of sparse TTN tensor to incident graph edges for each site
+
+  for v in vs
+    # collect all nontrivial entries of the TTN tensor at vertex v
+    entries = Tuple{MVector{ranks[v],Int},Scaled{ValType,Prod{Op}}}[]
+
+    # for every vertex, find all edges that contain this vertex
+    edges = filter(e -> dst(e) == v || src(e) == v, es)
+    # use the corresponding ordering as index order for tensor elements at this site
+    edge_orders[v] = edges
+    dim_in = findfirst(e -> dst(e) == v, edges)
+    edge_in = (isnothing(dim_in) ? [] : edges[dim_in])
+    dims_out = findall(e -> src(e) == v, edges)
+    edges_out = edges[dims_out]
+
+    # sanity check, leaves only have single incoming or outgoing edge
+    @assert !isempty(dims_out) || !isnothing(dim_in)
+    (isempty(dims_out) || isnothing(dim_in)) && @assert is_leaf(sites, v)
+
+    for term in os
+      # loop over OpSum and pick out terms that act on current vertex
+      crosses_vertex(term, sites, v) || continue
+
+      # filter out factors that come in from the direction of the incoming edge
+      incoming = filter(
+        t -> edge_in ∈ edge_path(sites, ITensors.site(t), v), ITensors.terms(term)
+      )
+      # filter out factor that acts on current vertex
+      onsite = filter(t -> (ITensors.site(t) == v), ITensors.terms(term))
+      # for every outgoing edge, filter out factors that go out along that edge
+      outgoing = Dict(
+        e => filter(t -> e ∈ edge_path(sites, v, ITensors.site(t)), ITensors.terms(term))
+        for e in edges_out
+      )
+
+      # translate into sparse tensor entry
+      T_inds = MVector{ranks[v]}(fill(-1, ranks[v]))
+      if !isnothing(dim_in) && !isempty(incoming)
+        T_inds[dim_in] = ITensors.posInLink!(linkmaps[edge_in], ITensors.argument(term)) # get incoming channel
+      end
+      for dout in dims_out
+        if !isempty(outgoing[edges[dout]])
+          T_inds[dout] = ITensors.posInLink!(linkmaps[edges[dout]], ITensors.argument(term)) # add outgoing channel
+        end
+      end
+      # if term starts at this site, add its coefficient as a site factor
+      site_coef = one(C)
+      if (isnothing(dim_in) || T_inds[dim_in] == -1) &&
+        ITensors.argument(term) ∉ site_coef_done
+        site_coef = ITensors.coefficient(term)
+        push!(site_coef_done, ITensors.argument(term))
+      end
+      # add onsite identity for interactions passing through vertex
+      if isempty(onsite)
+        if !ITensors.using_auto_fermion() && isfermionic(incoming, sites)
+          error("No verified fermion support for automatic TTN constructor!") # no verified support, just throw error
+        else
+          push!(onsite, Op("Id", v))
+        end
+      end
+      # save indices and value of sparse tensor entry
+      el = (T_inds, site_coef * Prod(onsite))
+      push!(entries, el)
+    end
+
+    # handle start and end of operator terms and convert to sparse array
+    linkdims = Tuple([
+      (isempty(linkmaps[e]) ? 0 : maximum(values(linkmaps[e]))) + 2 for e in edges
+    ])
+    T = SparseArray{Sum{Scaled{ValType,Prod{Op}}},ranks[v]}(undef, linkdims)
+    for (T_inds, t) in entries
+      if !isnothing(dim_in)
+        if T_inds[dim_in] == -1
+          T_inds[dim_in] = 1 # always start in first channel
+        else
+          T_inds[dim_in] += 1 # shift regular channel
+        end
+      end
+      if !isempty(dims_out)
+        end_dims = filter(d -> T_inds[d] == -1, dims_out)
+        normal_dims = filter(d -> T_inds[d] != -1, dims_out)
+        T_inds[end_dims] .= linkdims[end_dims] # always end in last channel
+        T_inds[normal_dims] .+= 1 # shift regular channels
+      end
+      T[T_inds...] += t
+    end
+    # add starting and ending identity operators
+    if isnothing(dim_in)
+      T[ones(Int, ranks[v])...] += one(ValType) * Prod([Op("Id", v)]) # only one real starting identity
+    end
+    # ending identities are a little more involved
+    if !isnothing(dim_in)
+      T[linkdims...] += one(ValType) * Prod([Op("Id", v)]) # place identity if all channels end
+      # place identity from start of incoming channel to start of each single outgoing channel
+      idT_end_inds = [linkdims...]
+      idT_end_inds[dim_in] = 1
+      for dout in dims_out
+        idT_end_inds[dout] = 1
+        T[idT_end_inds...] += one(ValType) * Prod([Op("Id", v)])
+        idT_end_inds[dout] = linkdims[dout] # reset
+      end
+    end
+    sparseTTN[v] = T
+  end
+  return sparseTTN, edge_orders
+end
+
+"""
+    fsmTTN(os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V, kwargs...) where {C,V}
+
+Construct a dense TreeTensorNetwork from sparse finite state machine
+represenatation, without compression.
+"""
+function fsmTTN(
+  os::OpSum{C}, sites::IndsNetwork{V,<:Index}, root_vertex::V; trunc=false, kwargs...
+)::TTN where {C,V}
+  ValType = ITensors.determineValType(ITensors.terms(os))
+  # start from finite state machine
+  fsm, edge_orders = finite_state_machine(os, sites, root_vertex)
+  # some trickery to get link dimension for every edge
+  link_space = Dict{edgetype(sites),Index}()
+  function get_linkind!(link_space, e)
+    if !haskey(link_space, e)
+      d = findfirst(x -> (x == e || x == reverse(e)), edge_orders[src(e)])
+      link_space[e] = Index(size(fsm[src(e)], d), edge_tag(e))
+    end
+    return link_space[e]
+  end
+  # compress finite state machine into dense form
+  H = TTN(sites)
+  for v in vertices(sites)
+    linkinds = [get_linkind!(link_space, e) for e in edge_orders[v]]
+    linkdims = dim.(linkinds)
+    H[v] = ITensor()
+    for (T_ind, t) in nonzero_pairs(fsm[v])
+      any(map(x -> abs(coefficient(x)) > eps(), t)) || continue
+      T = zeros(ValType, linkdims...)
+      T[T_ind] += one(ValType)
+      T = itensor(T, linkinds)
+      H[v] += T * computeSiteSum(sites, t)
+    end
+  end
+  # add option for numerical truncation, but throw warning as this can fail sometimes
+  if trunc
+    @warn "Naive numerical truncation of TTN Hamiltonian may fail for larger systems."
+    # see https://github.com/ITensor/ITensors.jl/issues/526
+    lognormT = lognorm(H)
+    H /= exp(lognormT / nv(H)) # TODO: fix broadcasting for in-place assignment
+    H = truncate(H; root_vertex, kwargs...)
+    H *= exp(lognormT / nv(H))
+  end
+  return H
+end
+
+function computeSiteSum(
+  sites::IndsNetwork{V,<:Index}, ops::Sum{Scaled{C,Prod{Op}}}
+)::ITensor where {V,C}
+  ValType = ITensors.determineValType(ITensors.terms(ops))
+  v = ITensors.site(ITensors.argument(ops[1])[1])
+  T =
+    convert(ValType, coefficient(ops[1])) *
+    computeSiteProd(sites, ITensors.argument(ops[1]))
+  for j in 2:length(ops)
+    (ITensors.site(ITensors.argument(ops[j])[1]) != v) &&
+      error("Mismatch of vertex labels in computeSiteSum")
+    T +=
+      convert(ValType, coefficient(ops[j])) *
+      computeSiteProd(sites, ITensors.argument(ops[j]))
+  end
+  return T
 end

--- a/test/test_opsum_to_ttn.jl
+++ b/test/test_opsum_to_ttn.jl
@@ -55,31 +55,31 @@ using Test
     end
 
     @testset "Finite state machine" for root_vertex in leaf_vertices(is)
-    # get TTN Hamiltonian directly
-    Hfsm = ITensorNetworks.fsmTTN(H, is, root_vertex)
-    # get corresponding MPO Hamiltonian
-    Hline = MPO(relabel_sites(H, vmap), sites)
-    # compare resulting dense Hamiltonians
-    @disable_warn_order begin
-      Tttno = prod(Hline)
-      Tmpo = contract(Hfsm)
-    end
-    @test Tttno ≈ Tmpo rtol = 1e-6
+      # get TTN Hamiltonian directly
+      Hfsm = ITensorNetworks.fsmTTN(H, is, root_vertex)
+      # get corresponding MPO Hamiltonian
+      Hline = MPO(relabel_sites(H, vmap), sites)
+      # compare resulting dense Hamiltonians
+      @disable_warn_order begin
+        Tttno = prod(Hline)
+        Tmpo = contract(Hfsm)
+      end
+      @test Tttno ≈ Tmpo rtol = 1e-6
 
-    # same thing for longer range interactions
-    Hfsm_lr = ITensorNetworks.fsmTTN(Hlr, is, root_vertex)
-    Hline_lr = MPO(relabel_sites(Hlr, vmap), sites)
-    @disable_warn_order begin
-      Tttno_lr = prod(Hline_lr)
-      Tmpo_lr = contract(Hfsm_lr)
-    end
-    @test Tttno_lr ≈ Tmpo_lr rtol = 1e-6
+      # same thing for longer range interactions
+      Hfsm_lr = ITensorNetworks.fsmTTN(Hlr, is, root_vertex)
+      Hline_lr = MPO(relabel_sites(Hlr, vmap), sites)
+      @disable_warn_order begin
+        Tttno_lr = prod(Hline_lr)
+        Tmpo_lr = contract(Hfsm_lr)
+      end
+      @test Tttno_lr ≈ Tmpo_lr rtol = 1e-6
 
-    # check optional numerical truncation for finite state machine construction
-    Hfsm_trunc = ITensorNetworks.fsmTTN(H, is, root_vertex; trunc=true, cutoff=1e-10)
-    @test collect(edge_data(linkdims(Hfsm_trunc))) == [4, 3, 4, 3, 3]
+      # check optional numerical truncation for finite state machine construction
+      Hfsm_trunc = ITensorNetworks.fsmTTN(H, is, root_vertex; trunc=true, cutoff=1e-10)
+      @test collect(edge_data(linkdims(Hfsm_trunc))) == [4, 3, 4, 3, 3]
+    end
   end
-end
 
   @testset "Multiple onsite terms (regression test for issue #62)" begin
     grid_dims = (2, 1)


### PR DESCRIPTION
Fixes the manual compression in the `OpSum` to `TTN` converter. I switched the default `OpSum` to `TTN` converter to always use the compression now. As far as I can tell this now works for any combination of interactions (I extended the corresponding tests a bit), and always gives the correct compressed bond dimension.

I left the explicit finite state machine construction for now since this might be useful for debugging purposes, but it's no longer exported. Maybe this might be useful if we ever want to use a fully sparse Hamiltonian representation instead of always making a dense operator, but I can also remove it if you think that's better.