### PR TITLE
Pass truncation kwargs to `insert_local_tensor`

### DIFF
--- a/src/treetensornetworks/solvers/update_step.jl
+++ b/src/treetensornetworks/solvers/update_step.jl
@@ -185,7 +185,16 @@ function local_update(
   #end
 
   psi, spec = insert_local_tensor(
-    psi, phi, region; eigen_perturbation=drho, ortho, normalize, kwargs...
+    psi,
+    phi,
+    region;
+    eigen_perturbation=drho,
+    ortho,
+    normalize,
+    cutoff,
+    maxdim,
+    mindim,
+    kwargs...,
   )
 
   update!(


### PR DESCRIPTION
Explicitly pass the truncation keyword arguments when inserting a local tensor back into the network in `alternating_update`. These were probably pulled out at a higher level at some point and no longer made it to `insert_local_tensor`, so the 2-site sweeping routines weren't actually truncating.