### PR TITLE
Add more general ITensorNetwork constructors from collections of ITensors

### DIFF
--- a/src/itensornetwork.jl
+++ b/src/itensornetwork.jl
@@ -53,6 +53,10 @@ copy(tn::ITensorNetwork) = ITensorNetwork(copy(data_graph(tn)))
 # Construction from collections of ITensors
 #
 
+ITensorNetwork(vs::Vector, ts::Vector{ITensor}) = ITensorNetwork(Dictionary(vs, ts))
+
+ITensorNetwork(ts::Vector{<:Pair{<:Any,ITensor}}) = ITensorNetwork(dictionary(ts))
+
 function ITensorNetwork(ts::ITensorCollection)
   return ITensorNetwork{keytype(ts)}(ts)
 end

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -58,6 +58,25 @@ using Test
     @test inner_res isa Float64
   end
 
+  @testset "Constructors from ITensors" begin
+    i, j, k, l = Index.(fill(2, 4))
+    A = ITensor(i, j)
+    B = ITensor(j, k)
+    C = ITensor(k, l)
+
+    tn = ITensorNetwork([A, B, C])
+    @test issetequal(vertices(tn), [1, 2, 3])
+    @test issetequal(edges(tn), NamedEdge.([1 => 2, 2 => 3]))
+
+    tn = ITensorNetwork(["A", "B", "C"], [A, B, C])
+    @test issetequal(vertices(tn), ["A", "B", "C"])
+    @test issetequal(edges(tn), NamedEdge.(["A" => "B", "B" => "C"]))
+
+    tn = ITensorNetwork(["A" => A, "B" => B, "C" => C])
+    @test issetequal(vertices(tn), ["A", "B", "C"])
+    @test issetequal(edges(tn), NamedEdge.(["A" => "B", "B" => "C"]))
+  end
+
   @testset "Contract edge (regression test for issue #5)" begin
     dims = (2, 2)
     g = named_grid(dims)


### PR DESCRIPTION
For example:
```julia
i, j, k, l = Index.(fill(2, 4))
A = ITensor(i, j)
B = ITensor(j, k)
C = ITensor(k, l)
tn = ITensorNetwork(["A", "B", "C"], [A, B, C])
tn = ITensorNetwork(["A" => A, "B" => B, "C" => C])
```