### PR TITLE
`add(::ITensorNetwork, ::ITensorNetwork)` with `directsum` backend

### DIFF
--- a/src/ITensorNetworks.jl
+++ b/src/ITensorNetworks.jl
@@ -46,7 +46,6 @@ using ITensors:
   dim,
   orthocenter,
   ProjMPS,
-  add,
   set_nsite!
 using KrylovKit: exponentiate, eigsolve, linsolve
 using NamedGraphs:

--- a/src/ITensorNetworks.jl
+++ b/src/ITensorNetworks.jl
@@ -46,6 +46,7 @@ using ITensors:
   dim,
   orthocenter,
   ProjMPS,
+  add,
   set_nsite!
 using KrylovKit: exponentiate, eigsolve, linsolve
 using NamedGraphs:

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -884,8 +884,8 @@ is_multi_edge(tn::AbstractITensorNetwork, e) = length(linkinds(tn, e)) > 1
 function add(tn1::AbstractITensorNetwork, tn2::AbstractITensorNetwork)
   @assert issetequal(vertices(tn1), vertices(tn2))
 
-  tn1 = combine_linkinds(tn1; edges=filter(e -> length(linkinds(tn1, e)) > 1, edges(tn1)))
-  tn2 = combine_linkinds(tn2; edges=filter(e -> length(linkinds(tn2, e)) > 1, edges(tn2)))
+  tn1 = combine_linkinds(tn1; edges=filter(e -> is_multi_edge(tn1, e), edges(tn1)))
+  tn2 = combine_linkinds(tn2; edges=filter(e -> is_multi_edge(tn2, e), edges(tn2)))
 
   edges_tn1, edges_tn2 = edges(tn1), edges(tn2)
 

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -913,7 +913,7 @@ function add(tn1::AbstractITensorNetwork, tn2::AbstractITensorNetwork)
     e1_v = NamedEdge[NamedEdge(v => vn) for vn in neighbors(tn1, v)]
     e2_v = NamedEdge[NamedEdge(v => vn) for vn in neighbors(tn2, v)]
 
-    @assert Set(e1_v) == Set(e2_v)
+    @assert issetequal(e1_v, e2_v)
     tn1v_linkinds = Index[first(linkinds(tn1, e)) for e in e1_v]
     tn2v_linkinds = Index[first(linkinds(tn2, e)) for e in e1_v]
 

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -908,8 +908,8 @@ function add(tn1::AbstractITensorNetwork, tn2::AbstractITensorNetwork)
     e2_v = NamedEdge[NamedEdge(v => vn) for vn in neighbors(tn2, v)]
 
     @assert issetequal(e1_v, e2_v)
-    tn1v_linkinds = Index[first(linkinds(tn1, e)) for e in e1_v]
-    tn2v_linkinds = Index[first(linkinds(tn2, e)) for e in e1_v]
+    tn1v_linkinds = Index[only(linkinds(tn1, e)) for e in e1_v]
+    tn2v_linkinds = Index[only(linkinds(tn2, e)) for e in e1_v]
 
     @assert length(tn1v_linkinds) == length(tn2v_linkinds)
 

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -872,7 +872,7 @@ end
 
 """Check if an itensornetwork has multiple indices along at least one of its edges"""
 function has_multi_edge(tn::AbstractITensorNetwork)
-  any(e -> length(linkinds(tn, e)) > 1, edges(tn))
+  return any(e -> length(linkinds(tn, e)) > 1, edges(tn))
 end
 
 """Add two itensornetworks together by growing the bond dimension. The network structures need to be have the same vertex names, same site index on each vertex """
@@ -900,34 +900,38 @@ function add(tn1::AbstractITensorNetwork, tn2::AbstractITensorNetwork)
   @assert issetequal(edges_tn1, edges_tn2)
 
   tn12 = copy(tn1)
-  edge_index_map = Dict{NamedEdge,Index}()
+  new_edge_indices = Dict(
+    zip(
+      edges_tn1,
+      [
+        Index(
+          dim(only(linkinds(tn1, e))) + dim(only(linkinds(tn2, e))),
+          tags(only(linkinds(tn1, e))),
+        ) for e in edges_tn1
+      ],
+    ),
+  )
+
   #Create vertices of tn12 as direct sum of tn1[v] and tn2[v]. Work out the matching indices by matching edges. Make index tags those of tn1[v]
   for v in vertices(tn1)
     @assert siteinds(tn1, v) == siteinds(tn2, v)
-    e1_v = NamedEdge[NamedEdge(v => vn) for vn in neighbors(tn1, v)]
-    e2_v = NamedEdge[NamedEdge(v => vn) for vn in neighbors(tn2, v)]
+
+    e1_v = filter(x -> src(x) == v || dst(x) == v, edges_tn1)
+    e2_v = filter(x -> src(x) == v || dst(x) == v, edges_tn2)
 
     @assert issetequal(e1_v, e2_v)
     tn1v_linkinds = Index[only(linkinds(tn1, e)) for e in e1_v]
     tn2v_linkinds = Index[only(linkinds(tn2, e)) for e in e1_v]
+    tn12v_linkinds = Index[new_edge_indices[e] for e in e1_v]
 
     @assert length(tn1v_linkinds) == length(tn2v_linkinds)
 
-    tn12[v], s = ITensors.directsum(
+    tn12[v] = ITensors.directsum(
+      tn12v_linkinds,
       tn1[v] => Tuple(tn1v_linkinds),
       tn2[v] => Tuple(tn2v_linkinds);
       tags=tags.(Tuple(tn1v_linkinds)),
     )
-
-    #Keep track of which indices are now assigned to each tensor (at the source of e)
-    for (i, e) in enumerate(e1_v)
-      edge_index_map[e] = s[i]
-    end
-  end
-
-  #Rematch the indices (these got unmatched by the above function) of tensors sharing an edge based on the edge_index_map
-  for e in edges_tn1
-    tn12[dst(e)] = replaceind(tn12[dst(e)], edge_index_map[reverse(e)], edge_index_map[e])
   end
 
   return tn12

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -872,13 +872,7 @@ end
 
 """Check if an itensornetwork has multiple indices along at least one of its edges"""
 function has_multi_edge(tn::AbstractITensorNetwork)
-  for e in edges(tn)
-    if length(linkinds(tn, e)) > 1
-      return false
-    end
-  end
-
-  return true
+  any(e -> length(linkinds(tn, e)) > 1, edges(tn))
 end
 
 """Add two itensornetworks together by growing the bond dimension. The network structures need to be have the same vertex names, same site index on each vertex """

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -879,13 +879,14 @@ end
 
 """Check if the edge of an itensornetwork has multiple indices"""
 is_multi_edge(tn::AbstractITensorNetwork, e) = length(linkinds(tn, e)) > 1
+is_multi_edge(tn::AbstractITensorNetwork) = Base.Fix1(is_multi_edge, tn)
 
 """Add two itensornetworks together by growing the bond dimension. The network structures need to be have the same vertex names, same site index on each vertex """
 function add(tn1::AbstractITensorNetwork, tn2::AbstractITensorNetwork)
   @assert issetequal(vertices(tn1), vertices(tn2))
 
-  tn1 = combine_linkinds(tn1; edges=filter(e -> is_multi_edge(tn1, e), edges(tn1)))
-  tn2 = combine_linkinds(tn2; edges=filter(e -> is_multi_edge(tn2, e), edges(tn2)))
+  tn1 = combine_linkinds(tn1; edges=filter(is_multi_edge(tn1), edges(tn1)))
+  tn2 = combine_linkinds(tn2; edges=filter(is_multi_edge(tn2), edges(tn2)))
 
   edges_tn1, edges_tn2 = edges(tn1), edges(tn2)
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -12,7 +12,8 @@ import Base:
   isapprox,
   isassigned,
   iterate,
-  union
+  union,
+  +
 
 import NamedGraphs:
   vertextype,

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -92,7 +92,9 @@ import ITensors:
   nsite,
   # promotion and conversion
   promote_itensor_eltype,
-  scalartype
+  scalartype,
+  #adding
+  add
 
 using ITensors.ContractionSequenceOptimization: deepmap
 

--- a/test/test_additensornetworks.jl
+++ b/test/test_additensornetworks.jl
@@ -61,14 +61,14 @@ using Random
   ψψ_1 = inner_network(ψ1, ψ1)
   ψOψ_1 = inner_network(ψ1, Oψ1)
 
-  e12_alt =
+  expec_method1 =
     (
       ITensors.contract(ψOψ_1)[] +
       ITensors.contract(ψOψ_2)[] +
       2 * ITensors.contract(ψ1Oψ2)[]
     ) /
     (ITensors.contract(ψψ_1)[] + ITensors.contract(ψψ_2)[] + 2 * ITensors.contract(ψ1ψ2)[])
-  e12 = ITensors.contract(ψOψ_12)[] / ITensors.contract(ψψ_12)[]
+  expec_method2 = ITensors.contract(ψOψ_12)[] / ITensors.contract(ψψ_12)[]
 
-  @test e12 ≈ e12_alt
+  @test expec_method1 ≈ expec_method2
 end

--- a/test/test_additensornetworks.jl
+++ b/test/test_additensornetworks.jl
@@ -1,0 +1,74 @@
+using ITensorNetworks
+using ITensorNetworks: add_itensornetworks, inner_network
+using Test
+using Compat
+using ITensors
+using Metis
+using NamedGraphs
+using NamedGraphs: hexagonal_lattice_graph
+using Random
+using LinearAlgebra
+using SplitApplyCombine
+
+using Random
+
+@testset "add_itensornetworks" begin
+  Random.seed!(5623)
+  g = named_grid((2, 3))
+  s = siteinds("S=1/2", g)
+  ψ1 = ITensorNetwork(s, v -> "↑")
+  ψ2 = ITensorNetwork(s, v -> "↓")
+
+  ψ_GHZ = add_itensornetworks(ψ1, ψ2)
+
+  v = (2, 2)
+  Oψ_GHZ = copy(ψ_GHZ)
+  Oψ_GHZ[v] = apply(op("Sz", s[v]), Oψ_GHZ[v])
+
+  ψψ_GHZ = inner_network(ψ_GHZ, ψ_GHZ)
+  ψOψ_GHZ = inner_network(ψ_GHZ, Oψ_GHZ)
+
+  @test ITensors.contract(ψOψ_GHZ)[] / ITensors.contract(ψψ_GHZ)[] == 0.0
+
+  χ = 3
+  g = hexagonal_lattice_graph(1, 2)
+  s = siteinds("S=1/2", g)
+
+  v = rand(vertices(g))
+  ψ1 = randomITensorNetwork(s; link_space=χ)
+  ψ2 = randomITensorNetwork(s; link_space=χ)
+
+  ψ12 = add_itensornetworks(ψ1, ψ2)
+
+  Oψ12 = copy(ψ12)
+  Oψ12[v] = apply(op("Sz", s[v]), Oψ12[v])
+
+  Oψ1 = copy(ψ1)
+  Oψ1[v] = apply(op("Sz", s[v]), Oψ1[v])
+
+  Oψ2 = copy(ψ2)
+  Oψ2[v] = apply(op("Sz", s[v]), Oψ2[v])
+
+  ψψ_12 = inner_network(ψ12, ψ12)
+  ψOψ_12 = inner_network(ψ12, Oψ12)
+
+  ψ1ψ2 = inner_network(ψ1, ψ2)
+  ψ1Oψ2 = inner_network(ψ1, Oψ2)
+
+  ψψ_2 = inner_network(ψ2, ψ2)
+  ψOψ_2 = inner_network(ψ2, Oψ2)
+
+  ψψ_1 = inner_network(ψ1, ψ1)
+  ψOψ_1 = inner_network(ψ1, Oψ1)
+
+  e12_alt =
+    (
+      ITensors.contract(ψOψ_1)[] +
+      ITensors.contract(ψOψ_2)[] +
+      2 * ITensors.contract(ψ1Oψ2)[]
+    ) /
+    (ITensors.contract(ψψ_1)[] + ITensors.contract(ψψ_2)[] + 2 * ITensors.contract(ψ1ψ2)[])
+  e12 = ITensors.contract(ψOψ_12)[] / ITensors.contract(ψψ_12)[]
+
+  @test e12 ≈ e12_alt
+end

--- a/test/test_additensornetworks.jl
+++ b/test/test_additensornetworks.jl
@@ -1,11 +1,11 @@
 using ITensorNetworks
-using ITensorNetworks: add_itensornetworks, inner_network
+using ITensorNetworks: inner_network
 using Test
 using Compat
 using ITensors
 using Metis
 using NamedGraphs
-using NamedGraphs: hexagonal_lattice_graph
+using NamedGraphs: hexagonal_lattice_graph, rem_edge!
 using Random
 using LinearAlgebra
 using SplitApplyCombine
@@ -19,7 +19,7 @@ using Random
   ψ1 = ITensorNetwork(s, v -> "↑")
   ψ2 = ITensorNetwork(s, v -> "↓")
 
-  ψ_GHZ = add_itensornetworks(ψ1, ψ2)
+  ψ_GHZ = ψ1 + ψ2
 
   v = (2, 2)
   Oψ_GHZ = copy(ψ_GHZ)
@@ -32,22 +32,25 @@ using Random
 
   χ = 3
   g = hexagonal_lattice_graph(1, 2)
-  s = siteinds("S=1/2", g)
+
+  s1 = siteinds("S=1/2", g)
+  s2 = copy(s1)
+  rem_edge!(s2, NamedEdge((1, 1) => (1, 2)))
 
   v = rand(vertices(g))
-  ψ1 = randomITensorNetwork(s; link_space=χ)
-  ψ2 = randomITensorNetwork(s; link_space=χ)
+  ψ1 = randomITensorNetwork(s1; link_space=χ)
+  ψ2 = randomITensorNetwork(s2; link_space=χ)
 
-  ψ12 = add_itensornetworks(ψ1, ψ2)
+  ψ12 = ψ1 + ψ2
 
   Oψ12 = copy(ψ12)
-  Oψ12[v] = apply(op("Sz", s[v]), Oψ12[v])
+  Oψ12[v] = apply(op("Sz", s1[v]), Oψ12[v])
 
   Oψ1 = copy(ψ1)
-  Oψ1[v] = apply(op("Sz", s[v]), Oψ1[v])
+  Oψ1[v] = apply(op("Sz", s1[v]), Oψ1[v])
 
   Oψ2 = copy(ψ2)
-  Oψ2[v] = apply(op("Sz", s[v]), Oψ2[v])
+  Oψ2[v] = apply(op("Sz", s2[v]), Oψ2[v])
 
   ψψ_12 = inner_network(ψ12, ψ12)
   ψOψ_12 = inner_network(ψ12, Oψ12)


### PR DESCRIPTION
This PR adds the capability to add two `itensornetworks` provided they are of the same structure (edges, vertices).

Tests are included.