### PR TITLE
Resolve keyword argument issues

### DIFF
--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -445,7 +445,7 @@ function svd(
 )
   tn = copy(tn)
   left_inds = uniqueinds(tn, edge)
-  U, S, V = svd(tn[src(edge)], left_inds; lefttags=u_tags, right_tags=v_tags, kwargs...)
+  U, S, V = svd(tn[src(edge)], left_inds; lefttags=u_tags, righttags=v_tags, kwargs...)
 
   rem_vertex!(tn, src(edge))
   add_vertex!(tn, U_vertex)
@@ -562,7 +562,7 @@ function _truncate_edge(tn::AbstractITensorNetwork, edge::AbstractEdge; kwargs..
   tn = copy(tn)
   left_inds = uniqueinds(tn, edge)
   ltags = tags(tn, edge)
-  U, S, V = svd(tn[src(edge)], left_inds; lefttags=ltags, ortho="left", kwargs...)
+  U, S, V = svd(tn[src(edge)], left_inds; lefttags=ltags, kwargs...)
   tn[src(edge)] = U
   tn[dst(edge)] *= (S * V)
   return tn

--- a/src/gauging.jl
+++ b/src/gauging.jl
@@ -103,9 +103,7 @@ function vidal_gauge(
   mts = belief_propagation(
     ψψ, mts; contract_kwargs=(; alg="exact"), niters, target_precision=target_canonicalness
   )
-  return vidal_gauge(
-    ψ, mts; eigen_message_tensor_cutoff, regularization, niters, svd_kwargs...
-  )
+  return vidal_gauge(ψ, mts; eigen_message_tensor_cutoff, regularization, svd_kwargs...)
 end
 
 """Transform from an ITensor in the Vidal Gauge (bond tensors) to the Symmetric Gauge (message tensors)"""


### PR DESCRIPTION
Recent changes to `ITensor` mean that it is stricter about erroring over unsupported keyword arguments.

This raises errors in the current version of `ITensorNetworks`: especially in the internal `tree_solver` functions.

This PR aims at fixing these errors. I have picked up a few in `abstractitensornetwork.jl` and `gauging.jl` but a lot remain on the `tree_tensornetworks/solvers` and should be addressed.