### PR TITLE
Efficient implementation of `expect` for `AbstractTTN`

### DIFF
--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -440,7 +440,7 @@ function expect(
     @assert isone(length(sites[v]))
     #ToDo: Add compatibility with more than a single index per vertex
     op_v = op(operator, only(sites[v]))
-    res[v] = scalar(dag(state[v]) * apply(op_v, state[v]))
+    res[v] = (dag(state[v]) * apply(op_v, state[v]))[]
   end
   return mapreduce(typeof, promote_type, res).(res)
 end

--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -424,15 +424,17 @@ end
 function expect(
   operator::String,
   state::AbstractTTN;
-  sites=siteinds(state),
-  root_vertex=default_root_vertex(sites), #ToDo: verify that this is a sane default
+  vertices=vertices(state),
+  root_vertex=default_root_vertex(siteinds(state)), #ToDo: verify that this is a sane default
 )
   # ToDo: for performance it may be beneficial to also implement expect! and change the orthogonality center in place
   # assuming that the next algorithmic step can make use of the orthogonality center being moved to a different vertex
-  vertices = reverse(post_order_dfs_vertices(sites, root_vertex)) #ToDo: Verify that this is indeed the correct order for performance
+  sites=siteinds(state)
+  ordered_vertices = reverse(post_order_dfs_vertices(sites, root_vertex)) #ToDo: Verify that this is indeed the correct order for performance
   ElT = promote_itensor_eltype(state)
   res = Dictionary(vertices, Vector{ElT}(undef, length(vertices)))
-  for v in vertices
+  for v in ordered_vertices
+    !(v in vertices) && continue  #only compute expectation values for required vertices
     state = orthogonalize(state, v)
     @assert isone(length(sites[v]))
     Op = ITensors.op(operator, only(sites[v])) #ToDo: Add compatibility with more than a single index per vertex

--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -429,7 +429,7 @@ function expect(
 )
   # ToDo: for performance it may be beneficial to also implement expect! and change the orthogonality center in place
   # assuming that the next algorithmic step can make use of the orthogonality center being moved to a different vertex
-  sites=siteinds(state)
+  sites = siteinds(state)
   ordered_vertices = reverse(post_order_dfs_vertices(sites, root_vertex)) #ToDo: Verify that this is indeed the correct order for performance
   ElT = promote_itensor_eltype(state)
   res = Dictionary(vertices, Vector{ElT}(undef, length(vertices)))

--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -431,14 +431,13 @@ function expect(
   # assuming that the next algorithmic step can make use of the orthogonality center being moved to a different vertex
   sites = siteinds(state)
   ordered_vertices = reverse(post_order_dfs_vertices(sites, root_vertex)) #ToDo: Verify that this is indeed the correct order for performance
-  ElT = promote_itensor_eltype(state)
-  res = Dictionary(vertices, Vector{ElT}(undef, length(vertices)))
+  res = Dictionary(vertices, undef)
   for v in ordered_vertices
-    !(v in vertices) && continue  #only compute expectation values for required vertices
+    !(v in vertices) && continue
     state = orthogonalize(state, v)
     @assert isone(length(sites[v]))
-    Op = ITensors.op(operator, only(sites[v])) #ToDo: Add compatibility with more than a single index per vertex
-    res[v] = scalar(dag(state[v]) * apply(Op, state[v]))
+    op_v = op(operator, only(sites[v])) #ToDo: Add compatibility with more than a single index per vertex
+    res[v] = scalar(dag(state[v]) * apply(op_v, state[v]))
   end
-  return res
+  return mapreduce(typeof, promote_type, res).(res)
 end

--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -425,18 +425,21 @@ function expect(
   operator::String,
   state::AbstractTTN;
   vertices=vertices(state),
-  root_vertex=default_root_vertex(siteinds(state)), #ToDo: verify that this is a sane default
+  # ToDo: verify that this is a sane default
+  root_vertex=default_root_vertex(siteinds(state)),
 )
   # ToDo: for performance it may be beneficial to also implement expect! and change the orthogonality center in place
   # assuming that the next algorithmic step can make use of the orthogonality center being moved to a different vertex
+  # ToDo: Verify that this is indeed the correct order for performance
   sites = siteinds(state)
-  ordered_vertices = reverse(post_order_dfs_vertices(sites, root_vertex)) #ToDo: Verify that this is indeed the correct order for performance
+  ordered_vertices = reverse(post_order_dfs_vertices(sites, root_vertex))
   res = Dictionary(vertices, undef)
   for v in ordered_vertices
     !(v in vertices) && continue
     state = orthogonalize(state, v)
     @assert isone(length(sites[v]))
-    op_v = op(operator, only(sites[v])) #ToDo: Add compatibility with more than a single index per vertex
+    #ToDo: Add compatibility with more than a single index per vertex
+    op_v = op(operator, only(sites[v]))
     res[v] = scalar(dag(state[v]) * apply(op_v, state[v]))
   end
   return mapreduce(typeof, promote_type, res).(res)

--- a/test/test_treetensornetworks/test_expect.jl
+++ b/test/test_treetensornetworks/test_expect.jl
@@ -10,23 +10,23 @@ using Test
   res_a = expect("Sz", a)
   res_b = expect(b, "Sz")
   res_a = [res_a[v] for v in vertices(a)]
-  @test res_a ≈ res_b rtol=1e-6 
+  @test res_a ≈ res_b rtol = 1e-6
 end
 
 @testset "TTN expect" begin
-    tooth_lengths = fill(5, 6)
-    c = named_comb_tree(tooth_lengths)
-    s = siteinds("S=1/2", c)
-    d = Dict()
-    magnetization = Dict()
-    for (i, v) in enumerate(vertices(s))
-      d[v] = isodd(i) ? "Up" : "Dn"
-      magnetization[v] = isodd(i) ? 0.5 : -0.5
-    end
-    states = v -> d[v]
-    state = TTN(s, states)
-    res=expect("Sz", state)   # just testing that this doesn't go via expect for arbitrary tensor networks.
-    @test all([isapprox(res[v], magnetization[v],atol=1e-8) for v in vertices(s)])
+  tooth_lengths = fill(5, 6)
+  c = named_comb_tree(tooth_lengths)
+  s = siteinds("S=1/2", c)
+  d = Dict()
+  magnetization = Dict()
+  for (i, v) in enumerate(vertices(s))
+    d[v] = isodd(i) ? "Up" : "Dn"
+    magnetization[v] = isodd(i) ? 0.5 : -0.5
+  end
+  states = v -> d[v]
+  state = TTN(s, states)
+  res = expect("Sz", state)   # just testing that this doesn't go via expect for arbitrary tensor networks.
+  @test all([isapprox(res[v], magnetization[v]; atol=1e-8) for v in vertices(s)])
 end
 
 nothing

--- a/test/test_treetensornetworks/test_expect.jl
+++ b/test/test_treetensornetworks/test_expect.jl
@@ -25,7 +25,7 @@ end
   end
   states = v -> d[v]
   state = TTN(s, states)
-  res = expect("Sz", state)   # just testing that this doesn't go via expect for arbitrary tensor networks.
+  res = expect("Sz", state)
   @test all([isapprox(res[v], magnetization[v]; atol=1e-8) for v in vertices(s)])
 end
 

--- a/test/test_treetensornetworks/test_expect.jl
+++ b/test/test_treetensornetworks/test_expect.jl
@@ -1,0 +1,32 @@
+using ITensors
+using ITensorNetworks
+using Test
+
+@testset "MPS expect comparison with ITensors" begin
+  N = 25
+  s = siteinds("S=1/2", N)
+  a = random_mps(s; internal_inds_space=100)
+  b = MPS([a[v] for v in vertices(a)])
+  res_a = expect("Sz", a)
+  res_b = expect(b, "Sz")
+  res_a = [res_a[v] for v in vertices(a)]
+  @test res_a ≈ res_b rtol=1e-6 
+end
+
+@testset "TTN expect" begin
+    tooth_lengths = fill(5, 6)
+    c = named_comb_tree(tooth_lengths)
+    s = siteinds("S=1/2", c)
+    d = Dict()
+    magnetization = Dict()
+    for (i, v) in enumerate(vertices(s))
+      d[v] = isodd(i) ? "Up" : "Dn"
+      magnetization[v] = isodd(i) ? 0.5 : -0.5
+    end
+    states = v -> d[v]
+    state = TTN(s, states)
+    res=expect("Sz", state)   # just testing that this doesn't go via expect for arbitrary tensor networks.
+    @test all([isapprox(res[v], magnetization[v],atol=1e-8) for v in vertices(s)])
+end
+
+nothing


### PR DESCRIPTION
This PR addresses #128 and adds an implementation of expect that should allow evaluation of local observables at all sites in a `TTN` at linear cost in the number of vertices in the `TTN`.

Basic tests have been added:
- comparing with `ITensors.expect` evaluated on the output of `random_mps` converted to `ITensors.MPS`, as well as verifying the `Sz`
- expectation value for a product-TTN in the computational basis for a `comb_tree`.

Open issues:
- performance testing should be added at some point / optimality of implementation is not verified
- Currently does not support multiple site-indices per vertex. This could probably easily be addressed similar to the way this is handled in the `svd_ttn` for converting `OpSum` to `TTN`. 