### PR TITLE
Fill `ITensor` with zeros if empty after contracting with `ProjTTN`.

### DIFF
--- a/src/treetensornetworks/projttns/abstractprojttn.jl
+++ b/src/treetensornetworks/projttns/abstractprojttn.jl
@@ -80,6 +80,10 @@ function contract(P::AbstractProjTTN, v::ITensor)::ITensor
   for it in itensor_map
     Hv *= it
   end
+  if isempty(Hv)
+    Hv = similar(v)
+    Hv .= 0
+  end
   return Hv
 end
 


### PR DESCRIPTION
This PR ensures that the result of a `ProjTTN` to `ITensor` contraction always results in an ITensor with the same `flux` and the allowed blocks densely filled.
Lack of this edit leads to instability of `KrylovKit.exponentiate` when used on product states of fermionic systems with regions where the action of the projected Hamiltonian on the state vanishes. There may be more appropriate fixes to this at the ITensors level, if this PR is not compatible with planned changes to the ITensors storage.