### PR TITLE
Improve compatibility with arbitrary vertextypes and tree structures 

### DIFF
--- a/src/itensornetwork.jl
+++ b/src/itensornetwork.jl
@@ -82,21 +82,21 @@ end
 function ITensorNetwork{V}(
   eltype::Type, undef::UndefInitializer, graph::AbstractNamedGraph; kwargs...
 ) where {V}
-  return ITensorNetwork{V}(eltype, undef, IndsNetwork{V}(graph; kwargs...); kwargs...)
+  return ITensorNetwork{V}(eltype, undef, IndsNetwork{V}(graph; kwargs...))
 end
 
 function ITensorNetwork{V}(eltype::Type, graph::AbstractNamedGraph; kwargs...) where {V}
-  return ITensorNetwork{V}(eltype, IndsNetwork{V}(graph; kwargs...); kwargs...)
+  return ITensorNetwork{V}(eltype, IndsNetwork{V}(graph; kwargs...))
 end
 
 function ITensorNetwork{V}(
   undef::UndefInitializer, graph::AbstractNamedGraph; kwargs...
 ) where {V}
-  return ITensorNetwork{V}(undef, IndsNetwork{V}(graph; kwargs...); kwargs...)
+  return ITensorNetwork{V}(undef, IndsNetwork{V}(graph; kwargs...))
 end
 
 function ITensorNetwork{V}(graph::AbstractNamedGraph; kwargs...) where {V}
-  return ITensorNetwork{V}(IndsNetwork{V}(graph; kwargs...); kwargs...)
+  return ITensorNetwork{V}(IndsNetwork{V}(graph; kwargs...))
 end
 
 function ITensorNetwork(
@@ -191,7 +191,7 @@ function ITensorNetwork{V}(
   inds_network_merge = typeof(inds_network)(
     underlying_graph(inds_network); link_space, kwargs...
   )
-  inds_network = union(inds_network, inds_network_merge)
+  inds_network = union(inds_network_merge, inds_network)
   tn = ITensorNetwork{V}()
   for v in vertices(inds_network)
     add_vertex!(tn, v)

--- a/src/itensornetwork.jl
+++ b/src/itensornetwork.jl
@@ -184,11 +184,13 @@ function ITensorNetwork{V}(inds_network::IndsNetwork; kwargs...) where {V}
 end
 
 function ITensorNetwork{V}(
-  itensor_constructor::Function, inds_network::IndsNetwork; kwargs...
+  itensor_constructor::Function, inds_network::IndsNetwork; link_space=1, kwargs...
 ) where {V}
   # Graphs.jl uses `zero` to create a graph of the same type
   # without any vertices or edges.
-  inds_network_merge = typeof(inds_network)(underlying_graph(inds_network); kwargs...)
+  inds_network_merge = typeof(inds_network)(
+    underlying_graph(inds_network); link_space, kwargs...
+  )
   inds_network = union(inds_network, inds_network_merge)
   tn = ITensorNetwork{V}()
   for v in vertices(inds_network)

--- a/src/itensornetwork.jl
+++ b/src/itensornetwork.jl
@@ -82,21 +82,21 @@ end
 function ITensorNetwork{V}(
   eltype::Type, undef::UndefInitializer, graph::AbstractNamedGraph; kwargs...
 ) where {V}
-  return ITensorNetwork{V}(eltype, undef, IndsNetwork{V}(graph; kwargs...))
+  return ITensorNetwork{V}(eltype, undef, IndsNetwork{V}(graph; kwargs...); kwargs...)
 end
 
 function ITensorNetwork{V}(eltype::Type, graph::AbstractNamedGraph; kwargs...) where {V}
-  return ITensorNetwork{V}(eltype, IndsNetwork{V}(graph; kwargs...))
+  return ITensorNetwork{V}(eltype, IndsNetwork{V}(graph; kwargs...); kwargs...)
 end
 
 function ITensorNetwork{V}(
   undef::UndefInitializer, graph::AbstractNamedGraph; kwargs...
 ) where {V}
-  return ITensorNetwork{V}(undef, IndsNetwork{V}(graph; kwargs...))
+  return ITensorNetwork{V}(undef, IndsNetwork{V}(graph; kwargs...); kwargs...)
 end
 
 function ITensorNetwork{V}(graph::AbstractNamedGraph; kwargs...) where {V}
-  return ITensorNetwork{V}(IndsNetwork{V}(graph; kwargs...))
+  return ITensorNetwork{V}(IndsNetwork{V}(graph; kwargs...); kwargs...)
 end
 
 function ITensorNetwork(

--- a/src/models.jl
+++ b/src/models.jl
@@ -93,7 +93,7 @@ function heisenberg(g::AbstractGraph; J1=1, J2=0, h=0)
   end
   for (i, v) in enumerate(vertices(g))
     if !iszero(h[i])
-      ℋ += h[i], "Sz", maybe_only(v)
+      ℋ += h[i], "Sz", v
     end
   end
   return ℋ

--- a/src/models.jl
+++ b/src/models.jl
@@ -13,21 +13,21 @@ function tight_binding(g::AbstractGraph; t=1, tp=0, h=0)
   ℋ = OpSum()
   if !iszero(t)
     for e in edges(g)
-      ℋ -= t, "Cdag", maybe_only(src(e)), "C", maybe_only(dst(e))
-      ℋ -= t, "Cdag", maybe_only(dst(e)), "C", maybe_only(src(e))
+      ℋ -= t, "Cdag", src(e), "C", dst(e)
+      ℋ -= t, "Cdag", dst(e), "C", src(e)
     end
   end
   if !iszero(t')
     for (i, v) in enumerate(vertices(g))
       for nn in next_nearest_neighbors(g, v)
-        ℋ -= tp, "Cdag", maybe_only(v), "C", maybe_only(nn)
-        ℋ -= tp, "Cdag", maybe_only(nn), "C", maybe_only(v)
+        ℋ -= tp, "Cdag", v, "C", nn
+        ℋ -= tp, "Cdag", nn, "C", v
       end
     end
   end
   for (i, v) in enumerate(vertices(g))
     if !iszero(h[i])
-      ℋ -= h[i], "N", maybe_only(v)
+      ℋ -= h[i], "N", v
     end
   end
   return ℋ
@@ -41,29 +41,29 @@ function hubbard(g::AbstractGraph; U=0, t=1, tp=0, h=0)
   ℋ = OpSum()
   if !iszero(t)
     for e in edges(g)
-      ℋ -= t, "Cdagup", maybe_only(src(e)), "Cup", maybe_only(dst(e))
-      ℋ -= t, "Cdagup", maybe_only(dst(e)), "Cup", maybe_only(src(e))
-      ℋ -= t, "Cdagdn", maybe_only(src(e)), "Cdn", maybe_only(dst(e))
-      ℋ -= t, "Cdagdn", maybe_only(dst(e)), "Cdn", maybe_only(src(e))
+      ℋ -= t, "Cdagup", src(e), "Cup", dst(e)
+      ℋ -= t, "Cdagup", dst(e), "Cup", src(e)
+      ℋ -= t, "Cdagdn", src(e), "Cdn", dst(e)
+      ℋ -= t, "Cdagdn", dst(e), "Cdn", src(e)
     end
   end
   if !iszero(tp)
     # TODO, more clever way of looping over next to nearest neighbors?
     for (i, v) in enumerate(vertices(g))
       for nn in next_nearest_neighbors(g, v)
-        ℋ -= tp, "Cdagup", maybe_only(v), "Cup", maybe_only(nn)
-        ℋ -= tp, "Cdagup", maybe_only(nn), "Cup", maybe_only(v)
-        ℋ -= tp, "Cdagdn", maybe_only(v), "Cdn", maybe_only(nn)
-        ℋ -= tp, "Cdagdn", maybe_only(nn), "Cdn", maybe_only(v)
+        ℋ -= tp, "Cdagup", v, "Cup", nn
+        ℋ -= tp, "Cdagup", nn, "Cup", v
+        ℋ -= tp, "Cdagdn", v, "Cdn", nn
+        ℋ -= tp, "Cdagdn", nn, "Cdn", v
       end
     end
   end
   for (i, v) in enumerate(vertices(g))
     if !iszero(h[i])
-      ℋ -= h[i], "Sz", maybe_only(v)
+      ℋ -= h[i], "Sz", v
     end
     if !iszero(U)
-      ℋ += U, "Nupdn", maybe_only(v)
+      ℋ += U, "Nupdn", v
     end
   end
   return ℋ
@@ -77,17 +77,17 @@ function heisenberg(g::AbstractGraph; J1=1, J2=0, h=0)
   ℋ = OpSum()
   if !iszero(J1)
     for e in edges(g)
-      ℋ += J1 / 2, "S+", maybe_only(src(e)), "S-", maybe_only(dst(e))
-      ℋ += J1 / 2, "S-", maybe_only(src(e)), "S+", maybe_only(dst(e))
-      ℋ += J1, "Sz", maybe_only(src(e)), "Sz", maybe_only(dst(e))
+      ℋ += J1 / 2, "S+", src(e), "S-", dst(e)
+      ℋ += J1 / 2, "S-", src(e), "S+", dst(e)
+      ℋ += J1, "Sz", src(e), "Sz", dst(e)
     end
   end
   if !iszero(J2)
     for (i, v) in enumerate(vertices(g))
       for nn in next_nearest_neighbors(g, v)
-        ℋ += J2 / 2, "S+", maybe_only(v), "S-", maybe_only(nn)
-        ℋ += J2 / 2, "S-", maybe_only(v), "S+", maybe_only(nn)
-        ℋ += J2, "Sz", maybe_only(v), "Sz", maybe_only(nn)
+        ℋ += J2 / 2, "S+", v, "S-", nn
+        ℋ += J2 / 2, "S-", v, "S+", nn
+        ℋ += J2, "Sz", v, "Sz", nn
       end
     end
   end
@@ -107,19 +107,19 @@ function ising(g::AbstractGraph; J1=-1, J2=0, h=0)
   ℋ = OpSum()
   if !iszero(J1)
     for e in edges(g)
-      ℋ += J1, "Sz", maybe_only(src(e)), "Sz", maybe_only(dst(e))
+      ℋ += J1, "Sz", src(e), "Sz", dst(e)
     end
   end
   if !iszero(J2)
     for (i, v) in enumerate(vertices(g))
       for nn in next_nearest_neighbors(g, v)
-        ℋ += J2, "Sz", maybe_only(v), "Sz", maybe_only(nn)
+        ℋ += J2, "Sz", v, "Sz", nn
       end
     end
   end
   for (i, v) in enumerate(vertices(g))
     if !iszero(h[i])
-      ℋ += h[i], "Sx", maybe_only(v)
+      ℋ += h[i], "Sx", v
     end
   end
   return ℋ

--- a/src/treetensornetworks/projttns/abstractprojttn.jl
+++ b/src/treetensornetworks/projttns/abstractprojttn.jl
@@ -129,13 +129,19 @@ end
 function invalidate_environments(P::AbstractProjTTN)
   ie = internal_edges(P)
   newenvskeys = filter(!in(ie), keys(environments(P)))
-  P = set_environments(P, getindices(environments(P), newenvskeys))
+  T=typeof(environments(P))
+  newenvs=getindices(environments(P),newenvskeys )
+  !(typeof(newenvs)==T) && (newenvs=T(newenvs))
+  P = set_environments(P, newenvs)
   return P
 end
 
 function invalidate_environment(P::AbstractProjTTN, e::AbstractEdge)
+  T=typeof(environments(P))
   newenvskeys = filter(!isequal(e), keys(environments(P)))
-  P = set_environments(P, getindices(environments(P), newenvskeys))
+  newenvs = getindices(environments(P),newenvskeys )
+  !(typeof(newenvs)==T) && (newenvs=T(newenvs))
+  P = set_environments(P, newenvs)
   return P
 end
 

--- a/src/treetensornetworks/projttns/abstractprojttn.jl
+++ b/src/treetensornetworks/projttns/abstractprojttn.jl
@@ -129,19 +129,14 @@ end
 function invalidate_environments(P::AbstractProjTTN)
   ie = internal_edges(P)
   newenvskeys = filter(!in(ie), keys(environments(P)))
-  T = typeof(environments(P))
-  newenvs = getindices(environments(P), newenvskeys)
-  !(typeof(newenvs) == T) && (newenvs = T(newenvs))
-  P = set_environments(P, newenvs)
+  P = set_environments(P, getindices_narrow_keytype(environments(P), newenvskeys))
   return P
 end
 
 function invalidate_environment(P::AbstractProjTTN, e::AbstractEdge)
   T = typeof(environments(P))
   newenvskeys = filter(!isequal(e), keys(environments(P)))
-  newenvs = getindices(environments(P), newenvskeys)
-  !(typeof(newenvs) == T) && (newenvs = T(newenvs))
-  P = set_environments(P, newenvs)
+  P = set_environments(P, getindices_narrow_keytype(environments(P), newenvskeys))
   return P
 end
 

--- a/src/treetensornetworks/projttns/abstractprojttn.jl
+++ b/src/treetensornetworks/projttns/abstractprojttn.jl
@@ -129,18 +129,18 @@ end
 function invalidate_environments(P::AbstractProjTTN)
   ie = internal_edges(P)
   newenvskeys = filter(!in(ie), keys(environments(P)))
-  T=typeof(environments(P))
-  newenvs=getindices(environments(P),newenvskeys )
-  !(typeof(newenvs)==T) && (newenvs=T(newenvs))
+  T = typeof(environments(P))
+  newenvs = getindices(environments(P), newenvskeys)
+  !(typeof(newenvs) == T) && (newenvs = T(newenvs))
   P = set_environments(P, newenvs)
   return P
 end
 
 function invalidate_environment(P::AbstractProjTTN, e::AbstractEdge)
-  T=typeof(environments(P))
+  T = typeof(environments(P))
   newenvskeys = filter(!isequal(e), keys(environments(P)))
-  newenvs = getindices(environments(P),newenvskeys )
-  !(typeof(newenvs)==T) && (newenvs=T(newenvs))
+  newenvs = getindices(environments(P), newenvskeys)
+  !(typeof(newenvs) == T) && (newenvs = T(newenvs))
   P = set_environments(P, newenvs)
   return P
 end

--- a/src/treetensornetworks/ttn.jl
+++ b/src/treetensornetworks/ttn.jl
@@ -45,8 +45,8 @@ function TTN(g::AbstractGraph, args...; kwargs...)
   return TTN(Float64, g, args...; kwargs...)
 end
 
-function TTN(eltype::Type{<:Number}, graph::AbstractGraph, args...; kwargs...)
-  itensor_network = ITensorNetwork(eltype, graph; kwargs...)
+function TTN(eltype::Type{<:Number}, graph::AbstractGraph, args...; link_space=1, kwargs...)
+  itensor_network = ITensorNetwork(eltype, graph; link_space, kwargs...)
   return TTN(itensor_network, args...)
 end
 
@@ -66,8 +66,8 @@ end
 # TODO: Implement `random_circuit_ttn` for non-trivial
 # bond dimensions and correlations.
 # TODO: Implement random_ttn for QN-Index
-function random_ttn(args...; link_space=1, kwargs...)
-  T = TTN(args...; link_space, kwargs...)
+function random_ttn(args...; kwargs...)
+  T = TTN(args...; kwargs...)
   randn!.(vertex_data(T))
   normalize!.(vertex_data(T))
   return T

--- a/src/treetensornetworks/ttn.jl
+++ b/src/treetensornetworks/ttn.jl
@@ -45,8 +45,8 @@ function TTN(g::AbstractGraph, args...; kwargs...)
   return TTN(Float64, g, args...; kwargs...)
 end
 
-function TTN(eltype::Type{<:Number}, graph::AbstractGraph, args...; link_space=1, kwargs...)
-  itensor_network = ITensorNetwork(eltype, graph; link_space, kwargs...)
+function TTN(eltype::Type{<:Number}, graph::AbstractGraph, args...; kwargs...)
+  itensor_network = ITensorNetwork(eltype, graph; kwargs...)
   return TTN(itensor_network, args...)
 end
 

--- a/src/treetensornetworks/ttn.jl
+++ b/src/treetensornetworks/ttn.jl
@@ -66,8 +66,8 @@ end
 # TODO: Implement `random_circuit_ttn` for non-trivial
 # bond dimensions and correlations.
 # TODO: Implement random_ttn for QN-Index
-function random_ttn(args...; kwargs...)
-  T = TTN(args...; kwargs...)
+function random_ttn(args...; link_space=1,kwargs...)
+  T = TTN(args...; link_space,kwargs...)
   randn!.(vertex_data(T))
   normalize!.(vertex_data(T))
   return T

--- a/src/treetensornetworks/ttn.jl
+++ b/src/treetensornetworks/ttn.jl
@@ -66,8 +66,8 @@ end
 # TODO: Implement `random_circuit_ttn` for non-trivial
 # bond dimensions and correlations.
 # TODO: Implement random_ttn for QN-Index
-function random_ttn(args...; link_space=1,kwargs...)
-  T = TTN(args...; link_space,kwargs...)
+function random_ttn(args...; link_space=1, kwargs...)
+  T = TTN(args...; link_space, kwargs...)
   randn!.(vertex_data(T))
   normalize!.(vertex_data(T))
   return T

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,3 +22,10 @@ function line_to_tree(line::Vector)
   end
   return [line_to_tree(line[1:(end - 1)]), line[end]]
 end
+
+function getindices_narrow_keytype(d::Dictionary, indices)
+  T = typeof(d)
+  d_at_indices = getindices(d, indices)
+  T != typeof(d_at_indices) && (d_at_indices = T(d_at_indices))
+  return d_at_indices
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,8 +24,5 @@ function line_to_tree(line::Vector)
 end
 
 function getindices_narrow_keytype(d::Dictionary, indices)
-  T = typeof(d)
-  d_at_indices = getindices(d, indices)
-  T != typeof(d_at_indices) && (d_at_indices = T(d_at_indices))
-  return d_at_indices
+  return convert(typeof(d), getindices(d, indices))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,9 +9,6 @@ end
 maybe_real(x::Real) = x
 maybe_real(x::Complex) = iszero(imag(x)) ? real(x) : x
 
-maybe_only(x) = x
-maybe_only(x::Tuple{T}) where {T} = only(x)
-
 front(itr, n=1) = Iterators.take(itr, length(itr) - n)
 tail(itr) = Iterators.drop(itr, 1)
 

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -185,7 +185,6 @@ using Test
     @test w[(1, 2)] ≈ log2(3)
     @test w[(2, 3)] ≈ log2(3)
     @test w[(3, 4)] ≈ log2(3)
-    #@show w[(3, 4)] ≈ log2(3)
     p1, p2, wc = GraphsFlows.mincut(tn, 2, 3)
     @test issetequal(p1, [1, 2])
     @test issetequal(p2, [3, 4])

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -185,7 +185,7 @@ using Test
     @test w[(1, 2)] ≈ log2(3)
     @test w[(2, 3)] ≈ log2(3)
     @test w[(3, 4)] ≈ log2(3)
-
+    #@show w[(3, 4)] ≈ log2(3)
     p1, p2, wc = GraphsFlows.mincut(tn, 2, 3)
     @test issetequal(p1, [1, 2])
     @test issetequal(p2, [3, 4])

--- a/test/test_itensornetwork.jl
+++ b/test/test_itensornetwork.jl
@@ -56,6 +56,10 @@ using Test
     @test sequence isa Vector
     inner_res = contract(inner_tn; sequence)[]
     @test inner_res isa Float64
+
+    # test that by default vertices are linked by bond-dimension 1 index
+    tn = ITensorNetwork(s)
+    @test isone(ITensors.dim(commonind(tn[(1,)], tn[(2,)])))
   end
 
   @testset "Constructors from ITensors" begin

--- a/test/test_treetensornetworks/test_solvers/test_tdvp.jl
+++ b/test/test_treetensornetworks/test_solvers/test_tdvp.jl
@@ -12,7 +12,6 @@ using Test
     cutoff = 1e-12
 
     s = siteinds("S=1/2", N)
-
     os = OpSum()
     for j in 1:(N - 1)
       os += 0.5, "S+", j, "S-", j + 1
@@ -381,12 +380,9 @@ using Test
 end
 
 @testset "Tree TDVP" begin
-  @testset "Basic TDVP" begin
+  @testset "Basic TDVP" for c in [named_comb_tree(fill(2, 3)), named_binary_tree(3)]
     cutoff = 1e-12
 
-    tooth_lengths = fill(2, 3)
-    root_vertex = (3, 2)
-    c = named_comb_tree(tooth_lengths)
     s = siteinds("S=1/2", c)
 
     os = ITensorNetworks.heisenberg(c)

--- a/test/test_treetensornetworks/test_solvers/test_tdvp.jl
+++ b/test/test_treetensornetworks/test_solvers/test_tdvp.jl
@@ -389,7 +389,7 @@ end
 
     H = TTN(os, s)
 
-    ψ0 = normalize!(random_ttn(s; link_space=10))
+    ψ0 = normalize!(random_ttn(s))
 
     # Time evolve forward:
     ψ1 = tdvp(H, -0.1im, ψ0; nsteps=1, cutoff, nsites=1)


### PR DESCRIPTION
This PR addresses some bugs in `alternating_update` when using certain `vertextype`s.

- Removed `maybe_only` from `utils.jl` and `models.jl` since it is not needed anymore
- Added default `link_space=1` to `random_ttn`, in line with `ITensors.randomMPS`, to avoid disconnecting product tree tebsir networks during first sweep.#140
- Make `alternating_update` compatible with e.g. binary trees. This used to fail due to [loss of type-information](https://github.com/andyferris/Dictionaries.jl/issues/97) of `Dictionaries.getindices` when applied to certain empty `Dictionary`.
- Added test for the latter functionality.

It does not address issues relating to ill-defined `isless` comparison on arbitrary `vertextype` in `ttn_svd`, which should be resolved in a separate PR.