### PR TITLE
Improve compatibility with tensor networks without internal vertices

### DIFF
--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -798,7 +798,11 @@ function hascommoninds(
   ::typeof(siteinds), A::AbstractITensorNetwork{V}, B::AbstractITensorNetwork{V}
 ) where {V}
   for v in vertices(A)
-    !hascommoninds(siteinds(A, v), siteinds(B, v)) && return false
+    if isempty(siteinds(A, v))
+      !isempty(siteinds(B, v)) && return false
+    else
+      !hascommoninds(siteinds(A, v), siteinds(B, v)) && return false
+    end
   end
   return true
 end
@@ -815,9 +819,13 @@ function check_hascommoninds(
     )
   end
   for v in vertices(A)
-    !hascommoninds(siteinds(A, v), siteinds(B, v)) && error(
-      "$(typeof(A)) A and $(typeof(B)) B must share site indices. On vertex $v, A has site indices $(siteinds(A, v)) while B has site indices $(siteinds(B, v)).",
-    )
+    if isempty(siteinds(A, v))
+      !(isempty(siteinds(B, v))) && return false
+    else
+      !hascommoninds(siteinds(A, v), siteinds(B, v)) && error(
+        "$(typeof(A)) A and $(typeof(B)) B must share site indices. On vertex $v, A has site indices $(siteinds(A, v)) while B has site indices $(siteinds(B, v)).",
+      )
+    end
   end
   return nothing
 end

--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -820,7 +820,9 @@ function check_hascommoninds(
   end
   for v in vertices(A)
     if isempty(siteinds(A, v))
-      !(isempty(siteinds(B, v))) && return false
+      !(isempty(siteinds(B, v))) && error(
+        "$(typeof(A)) A and $(typeof(B)) B must share site indices. On vertex $v, A has no site indices while B has site indices $(siteinds(B, v)).",
+      )
     else
       !hascommoninds(siteinds(A, v), siteinds(B, v)) && error(
         "$(typeof(A)) A and $(typeof(B)) B must share site indices. On vertex $v, A has site indices $(siteinds(A, v)) while B has site indices $(siteinds(B, v)).",

--- a/test/test_opsum_to_ttn.jl
+++ b/test/test_opsum_to_ttn.jl
@@ -247,7 +247,6 @@ end
         Tttno = contract(Hsvd)
       end
       @test Tttno ≈ Tmpo rtol = 1e-6
-
       Hsvd_lr = TTN(
         Hlr, is_missing_site; root_vertex=root_vertex, algorithm="svd", cutoff=1e-10
       )
@@ -257,6 +256,10 @@ end
         Tmpo_lr = contract(Hsvd_lr)
       end
       @test Tttno_lr ≈ Tmpo_lr rtol = 1e-6
+      # ToDo: move to a more appropriate file, since this is not related to OpSum to TTN conversion
+      # test whether Hamiltonian contracts with itself (used to error due to missing siteindices)
+      @test isa(inner(Hsvd, Hsvd), Number)
     end
   end
 end
+return nothing


### PR DESCRIPTION
This PR addresses some issues related to using Tensor Networks where the `vertex_data` at some vertices is empty, e.g. `Index[]`. In particular the behaviour of `check_hascommoninds` which is for example called when computing an inner product between two tensor networks is now comparing empty `vertex_data` as equal. A test has been added that verifies that an inner product can be taken.

ToDo:
- [ ] Maybe move test for missing siteinds functionality to a different file.
- [ ] Fix issue with specific state constructor for the case of missing siteinds. For example, `TTN(s,"Up")` is currently not functional if `s` is an `IndsNetwork` where at least one vertex has empty `vertex_data`.