### PR TITLE
Implement `inner(x,A,y)` for `TTN` via `BP`.

### DIFF
--- a/src/treetensornetworks/abstracttreetensornetwork.jl
+++ b/src/treetensornetworks/abstracttreetensornetwork.jl
@@ -365,20 +365,14 @@ end
 # Inner products
 #
 
-# TODO: implement using multi-graph disjoint union
-function inner(
-  y::AbstractTTN, A::AbstractTTN, x::AbstractTTN; root_vertex=default_root_vertex(x, A, y)
-)
-  traversal_order = reverse(post_order_dfs_vertices(x, root_vertex))
-  check_hascommoninds(siteinds, A, x)
-  check_hascommoninds(siteinds, A, y)
+# TODO: Remove dispatch on AbstractTTN (unless we want to trigger warning for trees if BP is nonexact)  
+function inner(y::AbstractTTN, A::AbstractTTN, x::AbstractTTN; kwargs...)
   ydag = sim(dag(y); sites=[])
-  x = sim(x; sites=[])
-  O = ydag[root_vertex] * A[root_vertex] * x[root_vertex]
-  for v in traversal_order[2:end]
-    O = O * ydag[v] * A[v] * x[v]
-  end
-  return O[]
+  blf = BilinearFormNetwork(A, ydag, x)
+  blf_scalar_bp = contract_with_BP(
+    tensornetwork(blf); outputlevel=1, partitioning=group(v -> first(v), vertices(blf))
+  )
+  return blf_scalar_bp
 end
 
 # TODO: implement using multi-graph disjoint

--- a/test/test_forms.jl
+++ b/test/test_forms.jl
@@ -1,4 +1,5 @@
 using ITensors
+using ITensors: contract
 using Graphs
 using NamedGraphs
 using ITensorNetworks
@@ -11,11 +12,13 @@ using ITensorNetworks:
   dual_index_map,
   bra_network,
   ket_network,
-  operator_network
+  operator_network,
+  contract_with_BP,
+  group
 using Test
 using Random
 
-@testset "FormNetworkss" begin
+@testset "FormNetworks" begin
   g = named_grid((1, 4))
   s_ket = siteinds("S=1/2", g)
   s_bra = prime(s_ket; links=[])
@@ -49,3 +52,33 @@ using Random
   @test underlying_graph(ket_network(qf)) == underlying_graph(ψket)
   @test underlying_graph(operator_network(qf)) == underlying_graph(A)
 end
+
+@testset "FormNetworks for TTN" begin
+  Random.seed!(1234)
+  Lx, Ly = 3, 3
+  χ = 2
+  g = named_comb_tree((Lx, Ly))
+  s = siteinds("S=1/2", g)
+  y = TTN(randomITensorNetwork(ComplexF64, s; link_space=χ))
+  x = TTN(randomITensorNetwork(ComplexF64, s; link_space=χ))
+
+  A = TTN(ITensorNetworks.heisenberg(s), s)
+  #First lets do it with the flattened version of the network
+  xy = inner_network(x, y; combine_linkinds=true)
+  xy_scalar = contract(xy)[]
+  xy_scalar_bp = contract_with_BP(xy)
+
+  @test_broken xy_scalar ≈ xy_scalar_bp
+
+  #Now lets keep it unflattened and do Block BP to keep the partitioned graph as a tree
+  xy = inner_network(x, y; combine_linkinds=false)
+  xy_scalar = contract(xy)[]
+  xy_scalar_bp = contract_with_BP(xy; partitioning=group(v -> first(v), vertices(xy)))
+
+  @test xy_scalar ≈ xy_scalar_bp
+  # test contraction of three layers for expectation values
+  # for TTN inner with this signature passes via contract_with_BP
+  @test inner(prime(x), A, y) ≈
+    inner(x, apply(A, y; nsweeps=10, maxdim=16, cutoff=1e-10, init=y)) rtol = 1e-6
+end
+nothing

--- a/test/test_treetensornetworks/test_treetensornetwork.jl
+++ b/test/test_treetensornetworks/test_treetensornetwork.jl
@@ -1,0 +1,53 @@
+using ITensors
+using ITensors: contract
+using ITensorNetworks
+using ITensorNetworks: contract_with_BP, group
+using Test
+
+@testset "TTN constructor defaulting to link_space=1" begin
+  tooth_lengths = fill(5, 6)
+  c = named_comb_tree(tooth_lengths)
+  s = siteinds("S=1/2", c)
+  d = Dict()
+  for (i, v) in enumerate(vertices(s))
+    d[v] = isodd(i) ? "Up" : "Dn"
+  end
+  states = v -> d[v]
+  #test a few signatures
+  state = TTN(s, states)
+  lds = edge_data(linkdims(state))
+  @test all([isone(lds[k]) for k in keys(lds)])
+  state = TTN(s)
+  lds = edge_data(linkdims(state))
+  @test all([isone(lds[k]) for k in keys(lds)])
+end
+
+@testset "Inner products for TTN via BP" begin
+  Random.seed!(1234)
+  Lx, Ly = 3, 3
+  χ = 2
+  g = named_comb_tree((Lx, Ly))
+  s = siteinds("S=1/2", g)
+  y = TTN(randomITensorNetwork(ComplexF64, s; link_space=χ))
+  x = TTN(randomITensorNetwork(ComplexF64, s; link_space=χ))
+
+  A = TTN(ITensorNetworks.heisenberg(s), s)
+  #First lets do it with the flattened version of the network
+  xy = inner_network(x, y; combine_linkinds=true)
+  xy_scalar = contract(xy)[]
+  xy_scalar_bp = contract_with_BP(xy)
+
+  @test_broken xy_scalar ≈ xy_scalar_bp
+
+  #Now lets keep it unflattened and do Block BP to keep the partitioned graph as a tree
+  xy = inner_network(x, y; combine_linkinds=false)
+  xy_scalar = contract(xy)[]
+  xy_scalar_bp = contract_with_BP(xy; partitioning=group(v -> first(v), vertices(xy)))
+
+  @test xy_scalar ≈ xy_scalar_bp
+  # test contraction of three layers for expectation values
+  # for TTN inner with this signature passes via contract_with_BP
+  @test inner(prime(x), A, y) ≈
+    inner(x, apply(A, y; nsweeps=10, maxdim=16, cutoff=1e-10, init=y)) rtol = 1e-6
+end
+nothing


### PR DESCRIPTION
This implements `inner(x,A,y)` for `x,A,y` all `AbstractTTN` with the same underlying graph, passing through the BP-backend. It addresses a performance issue of the previous implementation for certain `TTN`, leading to higher than necessary scaling in some situations (due to the traversal order). Thanks @JoeyT1994 for providing the `contract_with_BP` code.
Tests have been added to `test_forms.jl` to verify the correctness of the implementation.

This is not intended as a complete overhaul of the current implementations of `inner`, `expect` etc, which could be addressed in future PRs.