### PR TITLE
Fix bug in QuadraticFormNetwork constructor when no operator present

### DIFF
--- a/src/formnetworks/quadraticformnetwork.jl
+++ b/src/formnetworks/quadraticformnetwork.jl
@@ -59,7 +59,7 @@ function QuadraticFormNetwork(
   kwargs...,
 )
   blf = BilinearFormNetwork(
-    bra,
+    ket,
     ket;
     dual_site_index_map=dual_index_map,
     dual_link_index_map=dual_index_map,

--- a/test/test_forms.jl
+++ b/test/test_forms.jl
@@ -43,8 +43,12 @@ using Random: Random
   @test underlying_graph(operator_network(blf)) == underlying_graph(A)
   @test underlying_graph(bra_network(blf)) == underlying_graph(ψbra)
 
+  qf = QuadraticFormNetwork(ψket)
+  @test nv(qf) == 3 * nv(ψket)
+  @test isempty(flatten_siteinds(qf))
+
   qf = QuadraticFormNetwork(A, ψket)
-  @test nv(qf) == 2 * nv(ψbra) + nv(A)
+  @test nv(qf) == 2 * nv(ψket) + nv(A)
   @test isempty(flatten_siteinds(qf))
 
   v = (1, 1)


### PR DESCRIPTION
This PR fixes a bug in the `QuadraticFormNetwork(ket::AbstractITensorNetwork; kwarg...)` constructor where a `bra` variable was being passed that doesn't exist.

This PR should fix that and adds a quick test for the above constructor so that it would get caught in the future.