### PR TITLE
Remove flatten networks and refactor test

### DIFF
--- a/src/abstractitensornetwork.jl
+++ b/src/abstractitensornetwork.jl
@@ -663,38 +663,6 @@ function split_index(
   return tn
 end
 
-function flatten_networks(
-  tn1::AbstractITensorNetwork,
-  tn2::AbstractITensorNetwork;
-  map_bra_linkinds=sim,
-  flatten=true,
-  combine_linkinds=true,
-  kwargs...,
-)
-  @assert issetequal(vertices(tn1), vertices(tn2))
-  tn1 = map_bra_linkinds(tn1; sites=[])
-  flattened_net = ⊗(tn1, tn2; kwargs...)
-  if flatten
-    for v in vertices(tn1)
-      flattened_net = contract(flattened_net, (v, 2) => (v, 1); merged_vertex=v)
-    end
-  end
-  if combine_linkinds
-    flattened_net = ITensorNetworks.combine_linkinds(flattened_net)
-  end
-  return flattened_net
-end
-
-function flatten_networks(
-  tn1::AbstractITensorNetwork,
-  tn2::AbstractITensorNetwork,
-  tn3::AbstractITensorNetwork,
-  tn_tail::AbstractITensorNetwork...;
-  kwargs...,
-)
-  return flatten_networks(flatten_networks(tn1, tn2; kwargs...), tn3, tn_tail...; kwargs...)
-end
-
 function inner_network(x::AbstractITensorNetwork, y::AbstractITensorNetwork; kwargs...)
   return BilinearFormNetwork(x, y; kwargs...)
 end

--- a/test/test_contraction_sequence_to_graph.jl
+++ b/test/test_contraction_sequence_to_graph.jl
@@ -5,9 +5,7 @@ using ITensorNetworks:
   contraction_sequence_to_digraph,
   contraction_sequence_to_graph,
   contraction_tree_leaf_bipartition,
-  flatten_networks,
-  random_tensornetwork,
-  siteinds
+  random_tensornetwork
 using Test: @test, @testset
 using NamedGraphs.GraphsExtensions:
   is_leaf_vertex, leaf_vertices, non_leaf_edges, root_vertex
@@ -17,12 +15,10 @@ using NamedGraphs.NamedGraphGenerators: named_grid
   n = 3
   dims = (n, n)
   g = named_grid(dims)
-  s = siteinds("S=1/2", g)
 
-  ψ = random_tensornetwork(s; link_space=2)
-  ψψ = flatten_networks(ψ, ψ)
+  tn = random_tensornetwork(g; link_space=2)
 
-  seq = contraction_sequence(ψψ)
+  seq = contraction_sequence(tn)
 
   g_directed_seq = contraction_sequence_to_digraph(seq)
   g_seq_leaves = leaf_vertices(g_directed_seq)
@@ -37,16 +33,16 @@ using NamedGraphs.NamedGraphGenerators: named_grid
   for eb in non_leaf_edges(g_seq)
     vs = contraction_tree_leaf_bipartition(g_seq, eb)
     @test length(vs) == 2
-    @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(ψψ))
+    @test Set([v.I for v in vcat(vs[1], vs[2])]) == Set(vertices(tn))
   end
   #Check all internal vertices define a correct tripartition and all leaf vertices define a bipartition (tensor on that leafs vs tensor on rest of tree)
   for v in vertices(g_seq)
     if (!is_leaf_vertex(g_seq, v))
       @test length(v) == 3
-      @test Set([vsi.I for vsi in vcat(v[1], v[2], v[3])]) == Set(vertices(ψψ))
+      @test Set([vsi.I for vsi in vcat(v[1], v[2], v[3])]) == Set(vertices(tn))
     else
       @test length(v) == 2
-      @test Set([vsi.I for vsi in vcat(v[1], v[2])]) == Set(vertices(ψψ))
+      @test Set([vsi.I for vsi in vcat(v[1], v[2])]) == Set(vertices(tn))
     end
   end
 end


### PR DESCRIPTION
PR to remove `flatten_networks(...)` as it is not being used for anything meaningful anymore in the library.

The test where it was being used in `test_contraction_sequence_to_graph` now directly constructs a `flatened` network by just calling `ITensorNetwork(g; link_space =2)` avoiding any use of `siteinds`.

This should address Issue #164 